### PR TITLE
fix(surgeons): remove incorrect concentration label from Dr. Karlinsky's education

### DIFF
--- a/apps/web/lib/data/surgeons/surgeons-data.ts
+++ b/apps/web/lib/data/surgeons/surgeons-data.ts
@@ -17,7 +17,7 @@ export const surgeons: Surgeon[] = [
             portrait: '/images/surgeons/dr-karlinsky.webp',
         },
         education: [
-            'MD, Ross University School of Medicine (Cosmetic & Aesthetic Surgery Concentration)',
+            'MD, Ross University School of Medicine',
             'Residency, Dept. of Surgery, Beth Israel Medical Center, NYC',
             'Fellowship, Facial Plastic & Cosmetic Surgical Center, Abilene, Texas',
         ],


### PR DESCRIPTION
## Summary

- Removes the `(Cosmetic & Aesthetic Surgery Concentration)` qualifier from Dr. Karlinsky's MD degree entry in the surgeons data
- The degree itself is accurate; the concentration label was incorrect/inaccurate

## Test plan

- [ ] Verify Dr. Karlinsky's profile page displays the updated education entry correctly
- [ ] Confirm no other surgeon data was affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected surgeon profile information by removing redundant education detail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->