### PR TITLE
feat(analytics): add Google Tag Manager container

### DIFF
--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -87,6 +87,19 @@ export default function RootLayout({
     return (
         <html lang='en' className='scroll-smooth' suppressHydrationWarning>
             <head>
+                {/* Google Tag Manager */}
+                <Script
+                    id='gtm-head'
+                    strategy='afterInteractive'
+                    dangerouslySetInnerHTML={{
+                        __html: `(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','GTM-K7P3XZ75');`,
+                    }}
+                />
+
                 {/* Resource hints for external domains */}
                 <link rel='dns-prefetch' href='https://fonts.googleapis.com' />
                 <link
@@ -121,6 +134,15 @@ export default function RootLayout({
                 className={`${fontLato.variable} ${fontMono.variable} ${fontGeist.variable} ${fontPlayfair.variable} font-sans antialiased`}
                 suppressHydrationWarning
             >
+                {/* Google Tag Manager (noscript) */}
+                <noscript>
+                    <iframe
+                        src='https://www.googletagmanager.com/ns.html?id=GTM-K7P3XZ75'
+                        height='0'
+                        width='0'
+                        style={{ display: 'none', visibility: 'hidden' }}
+                    />
+                </noscript>
                 {/* Google Translate - Client-side only to avoid hydration errors */}
                 <GoogleTranslateInit />
                 <WebVitals />


### PR DESCRIPTION
## Summary
- Add GTM container `GTM-K7P3XZ75` to the root layout
- GTM head script added at the top of `<head>` using Next.js `<Script>` with `afterInteractive` strategy
- GTM noscript `<iframe>` fallback added immediately after the `<body>` tag

## Test plan
- [ ] Verify GTM container loads on the site using [Google Tag Assistant](https://tagassistant.google.com/)
- [ ] Confirm `GTM-K7P3XZ75` shows as active in GTM debug mode
- [ ] Check no layout shift or performance regression from the added scripts

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added Google Tag Manager integration to the application with fallback support for users without JavaScript enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->