### PR TITLE
feat(admin): add filters and page-size selector to contacts list

### DIFF
--- a/apps/admin/app/(dashboard)/contacts/page.tsx
+++ b/apps/admin/app/(dashboard)/contacts/page.tsx
@@ -13,6 +13,12 @@ import { Mail, Phone, Eye, Download } from 'lucide-react'
 import Link from 'next/link'
 
 import { ContactsFilterBar } from '@/components/contacts/contacts-filter-bar.component'
+import { PageSizeSelect } from '@/components/contacts/page-size-select.component'
+import {
+    DEFAULT_PAGE_SIZE,
+    PAGE_SIZE_OPTIONS,
+    type PageSize,
+} from '@/components/contacts/page-size.constants'
 import {
     getContactsPageData,
     parseContactFilters,
@@ -30,8 +36,15 @@ export const metadata = {
     description: 'View and manage contact form submissions',
 }
 
-const PAGE_SIZE = 10
 const MAX_PAGE = 1000
+
+function parsePageSize(raw: string | string[] | undefined): PageSize {
+    const value = Array.isArray(raw) ? raw[0] : raw
+    const parsed = Number(value)
+    return (PAGE_SIZE_OPTIONS as readonly number[]).includes(parsed)
+        ? (parsed as PageSize)
+        : DEFAULT_PAGE_SIZE
+}
 
 type SearchParams = Promise<Record<string, string | string[] | undefined>>
 
@@ -46,14 +59,16 @@ export default async function ContactsPage({
     if (!Number.isInteger(page) || !Number.isFinite(page) || page < 1) page = 1
     page = Math.min(page, MAX_PAGE)
 
+    const pageSize = parsePageSize(params.pageSize)
+
     const filters = parseContactFilters(params)
     const { contacts, total, sourceOptions, mediumOptions } =
         await getContactsPageData(filters)
 
-    const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE))
+    const totalPages = Math.max(1, Math.ceil(total / pageSize))
     const safePage = Math.min(page, totalPages)
-    const pageStart = (safePage - 1) * PAGE_SIZE
-    const pageContacts = contacts.slice(pageStart, pageStart + PAGE_SIZE)
+    const pageStart = (safePage - 1) * pageSize
+    const pageContacts = contacts.slice(pageStart, pageStart + pageSize)
 
     const hasFilterState =
         filters.sources.length > 0 ||
@@ -230,37 +245,46 @@ export default async function ContactsPage({
                 </CardContent>
             </Card>
 
-            {totalPages > 1 && (
-                <div className='flex items-center justify-center gap-2'>
-                    <Button
-                        variant='outline'
-                        size='sm'
-                        disabled={safePage <= 1}
-                        asChild={safePage > 1}
-                    >
-                        {safePage > 1 ? (
-                            <Link href={pageHref(safePage - 1)}>Previous</Link>
-                        ) : (
-                            <span>Previous</span>
-                        )}
-                    </Button>
+            <div className='flex flex-wrap items-center justify-between gap-3'>
+                <PageSizeSelect pageSize={pageSize} />
+                {totalPages > 1 ? (
+                    <div className='flex items-center gap-2'>
+                        <Button
+                            variant='outline'
+                            size='sm'
+                            disabled={safePage <= 1}
+                            asChild={safePage > 1}
+                        >
+                            {safePage > 1 ? (
+                                <Link href={pageHref(safePage - 1)}>
+                                    Previous
+                                </Link>
+                            ) : (
+                                <span>Previous</span>
+                            )}
+                        </Button>
+                        <span className='text-muted-foreground text-sm'>
+                            Page {safePage} of {totalPages}
+                        </span>
+                        <Button
+                            variant='outline'
+                            size='sm'
+                            disabled={safePage >= totalPages}
+                            asChild={safePage < totalPages}
+                        >
+                            {safePage < totalPages ? (
+                                <Link href={pageHref(safePage + 1)}>Next</Link>
+                            ) : (
+                                <span>Next</span>
+                            )}
+                        </Button>
+                    </div>
+                ) : (
                     <span className='text-muted-foreground text-sm'>
-                        Page {safePage} of {totalPages}
+                        {total} {total === 1 ? 'contact' : 'contacts'}
                     </span>
-                    <Button
-                        variant='outline'
-                        size='sm'
-                        disabled={safePage >= totalPages}
-                        asChild={safePage < totalPages}
-                    >
-                        {safePage < totalPages ? (
-                            <Link href={pageHref(safePage + 1)}>Next</Link>
-                        ) : (
-                            <span>Next</span>
-                        )}
-                    </Button>
-                </div>
-            )}
+                )}
+            </div>
         </div>
     )
 }

--- a/apps/admin/app/(dashboard)/contacts/page.tsx
+++ b/apps/admin/app/(dashboard)/contacts/page.tsx
@@ -12,8 +12,15 @@ import {
 import { Mail, Phone, Eye, Download } from 'lucide-react'
 import Link from 'next/link'
 
-import { getContacts } from '@/lib/queries/contacts.query'
-import type { ContactListItem } from '@/lib/types/contacts/contacts.type'
+import { ContactsFilterBar } from '@/components/contacts/contacts-filter-bar.component'
+import {
+    getContactsPageData,
+    parseContactFilters,
+} from '@/lib/queries/contacts-filters'
+import type {
+    ClassifiedContactListItem,
+    ContactListItem,
+} from '@/lib/types/contacts/contacts.type'
 
 export const dynamic = 'force-dynamic'
 export const maxDuration = 30
@@ -23,7 +30,10 @@ export const metadata = {
     description: 'View and manage contact form submissions',
 }
 
-type SearchParams = Promise<{ page?: string }>
+const PAGE_SIZE = 10
+const MAX_PAGE = 1000
+
+type SearchParams = Promise<Record<string, string | string[] | undefined>>
 
 export default async function ContactsPage({
     searchParams,
@@ -32,19 +42,26 @@ export default async function ContactsPage({
 }) {
     const params = await searchParams
 
-    const MAX_PAGE = 1000
     let page = Number(params.page)
-
-    // Validate: ensure it's a finite integer and positive
-    if (!Number.isInteger(page) || !Number.isFinite(page) || page < 1) {
-        page = 1
-    }
-
-    // Clamp to safe range
+    if (!Number.isInteger(page) || !Number.isFinite(page) || page < 1) page = 1
     page = Math.min(page, MAX_PAGE)
 
-    const { contacts, total } = await getContacts(page, 10)
-    const totalPages = Math.ceil(total / 10)
+    const filters = parseContactFilters(params)
+    const { contacts, total, sourceOptions, mediumOptions } =
+        await getContactsPageData(filters)
+
+    const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE))
+    const safePage = Math.min(page, totalPages)
+    const pageStart = (safePage - 1) * PAGE_SIZE
+    const pageContacts = contacts.slice(pageStart, pageStart + PAGE_SIZE)
+
+    const hasFilterState =
+        filters.sources.length > 0 ||
+        filters.mediums.length > 0 ||
+        filters.dateRangePreset !== '28d'
+
+    const exportHref = buildExportHref(params)
+    const pageHref = (targetPage: number) => buildPageHref(params, targetPage)
 
     return (
         <div className='space-y-6'>
@@ -59,12 +76,22 @@ export default async function ContactsPage({
                     </p>
                 </div>
                 <Button variant='outline' asChild>
-                    <a href='/api/contacts/export' download>
+                    <a href={exportHref} download>
                         <Download className='mr-2 h-4 w-4' />
                         Export CSV
                     </a>
                 </Button>
             </div>
+
+            <ContactsFilterBar
+                sourceOptions={sourceOptions}
+                mediumOptions={mediumOptions}
+                selectedSources={filters.sources}
+                selectedMediums={filters.mediums}
+                dateRangePreset={filters.dateRangePreset}
+                startDate={filters.startDate}
+                endDate={filters.endDate}
+            />
 
             <Card>
                 <CardContent className='p-0'>
@@ -73,7 +100,7 @@ export default async function ContactsPage({
                             <TableRow>
                                 <TableHead>Contact</TableHead>
                                 <TableHead>Subject / Procedure</TableHead>
-                                <TableHead>Source</TableHead>
+                                <TableHead>Attribution</TableHead>
                                 <TableHead>UTM</TableHead>
                                 <TableHead>Date</TableHead>
                                 <TableHead className='w-[100px]'>
@@ -82,17 +109,32 @@ export default async function ContactsPage({
                             </TableRow>
                         </TableHeader>
                         <TableBody>
-                            {contacts.length === 0 ? (
+                            {pageContacts.length === 0 ? (
                                 <TableRow>
                                     <TableCell
                                         colSpan={6}
-                                        className='text-muted-foreground py-8 text-center'
+                                        className='text-muted-foreground py-10 text-center'
                                     >
-                                        No contact submissions yet
+                                        {hasFilterState ? (
+                                            <div className='space-y-2'>
+                                                <p>
+                                                    No contacts match these
+                                                    filters.
+                                                </p>
+                                                <Link
+                                                    href='/contacts'
+                                                    className='text-foreground underline-offset-4 hover:underline'
+                                                >
+                                                    Clear filters
+                                                </Link>
+                                            </div>
+                                        ) : (
+                                            'No contact submissions yet'
+                                        )}
                                     </TableCell>
                                 </TableRow>
                             ) : (
-                                contacts.map((contact) => (
+                                pageContacts.map((contact) => (
                                     <TableRow key={contact.id}>
                                         <TableCell>
                                             <div className='space-y-1'>
@@ -142,9 +184,9 @@ export default async function ContactsPage({
                                             </div>
                                         </TableCell>
                                         <TableCell>
-                                            <span className='text-muted-foreground text-sm'>
-                                                {contact.source ?? 'Direct'}
-                                            </span>
+                                            <AttributionCell
+                                                contact={contact}
+                                            />
                                         </TableCell>
                                         <TableCell>
                                             <UtmBadges contact={contact} />
@@ -188,42 +230,58 @@ export default async function ContactsPage({
                 </CardContent>
             </Card>
 
-            {/* Pagination */}
             {totalPages > 1 && (
                 <div className='flex items-center justify-center gap-2'>
                     <Button
                         variant='outline'
                         size='sm'
-                        disabled={page <= 1}
-                        asChild={page > 1}
+                        disabled={safePage <= 1}
+                        asChild={safePage > 1}
                     >
-                        {page > 1 ? (
-                            <Link href={`/contacts?page=${page - 1}`}>
-                                Previous
-                            </Link>
+                        {safePage > 1 ? (
+                            <Link href={pageHref(safePage - 1)}>Previous</Link>
                         ) : (
                             <span>Previous</span>
                         )}
                     </Button>
                     <span className='text-muted-foreground text-sm'>
-                        Page {page} of {totalPages}
+                        Page {safePage} of {totalPages}
                     </span>
                     <Button
                         variant='outline'
                         size='sm'
-                        disabled={page >= totalPages}
-                        asChild={page < totalPages}
+                        disabled={safePage >= totalPages}
+                        asChild={safePage < totalPages}
                     >
-                        {page < totalPages ? (
-                            <Link href={`/contacts?page=${page + 1}`}>
-                                Next
-                            </Link>
+                        {safePage < totalPages ? (
+                            <Link href={pageHref(safePage + 1)}>Next</Link>
                         ) : (
                             <span>Next</span>
                         )}
                     </Button>
                 </div>
             )}
+        </div>
+    )
+}
+
+function AttributionCell({ contact }: { contact: ClassifiedContactListItem }) {
+    return (
+        <div className='flex flex-col gap-1'>
+            <div className='flex items-center gap-1'>
+                <Badge variant='secondary' className='text-xs'>
+                    {contact.attribution.source}
+                </Badge>
+                <Badge variant='outline' className='text-xs'>
+                    {contact.attribution.medium}
+                </Badge>
+            </div>
+            {contact.source &&
+                contact.source !== contact.attribution.source && (
+                    <span className='text-muted-foreground text-xs'>
+                        raw: {contact.source}
+                    </span>
+                )}
         </div>
     )
 }
@@ -273,4 +331,39 @@ function formatDate(date: Date): string {
         day: 'numeric',
         year: 'numeric',
     }).format(new Date(date))
+}
+
+function serializeParams(
+    params: Record<string, string | string[] | undefined>
+): URLSearchParams {
+    const out = new URLSearchParams()
+    for (const [key, value] of Object.entries(params)) {
+        if (value === undefined) continue
+        if (Array.isArray(value)) {
+            for (const v of value) if (v) out.append(key, v)
+        } else {
+            if (value) out.set(key, value)
+        }
+    }
+    return out
+}
+
+function buildPageHref(
+    params: Record<string, string | string[] | undefined>,
+    targetPage: number
+): string {
+    const next = serializeParams(params)
+    if (targetPage <= 1) next.delete('page')
+    else next.set('page', String(targetPage))
+    const query = next.toString()
+    return query ? `/contacts?${query}` : '/contacts'
+}
+
+function buildExportHref(
+    params: Record<string, string | string[] | undefined>
+): string {
+    const next = serializeParams(params)
+    next.delete('page')
+    const query = next.toString()
+    return query ? `/api/contacts/export?${query}` : '/api/contacts/export'
 }

--- a/apps/admin/app/api/contacts/export/route.ts
+++ b/apps/admin/app/api/contacts/export/route.ts
@@ -1,46 +1,21 @@
-import { NextResponse } from 'next/server'
-import { db } from '@workspace/db/client'
-import { contactSubmission } from '@workspace/db/schema/contact'
-import { desc } from 'drizzle-orm'
+import { NextResponse, type NextRequest } from 'next/server'
+
+import {
+    getFilteredClassifiedContacts,
+    parseContactFilters,
+} from '@/lib/queries/contacts-filters'
 import { isAuthenticated } from '@/lib/utils/auth.util'
 
-export async function GET() {
+export async function GET(request: NextRequest) {
     try {
         const authenticated = await isAuthenticated()
         if (!authenticated) {
             return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
         }
 
-        const contacts = await db
-            .select({
-                id: contactSubmission.id,
-                name: contactSubmission.name,
-                firstName: contactSubmission.firstName,
-                lastName: contactSubmission.lastName,
-                email: contactSubmission.email,
-                phone: contactSubmission.phone,
-                subject: contactSubmission.subject,
-                message: contactSubmission.message,
-                procedure: contactSubmission.procedure,
-                preferredContactTime: contactSubmission.preferredContactTime,
-                source: contactSubmission.source,
-                utmSource: contactSubmission.utmSource,
-                utmMedium: contactSubmission.utmMedium,
-                utmCampaign: contactSubmission.utmCampaign,
-                utmContent: contactSubmission.utmContent,
-                utmTerm: contactSubmission.utmTerm,
-                gclid: contactSubmission.gclid,
-                fbclid: contactSubmission.fbclid,
-                ttclid: contactSubmission.ttclid,
-                referrer: contactSubmission.referrer,
-                landingPage: contactSubmission.landingPage,
-                ipAddress: contactSubmission.ipAddress,
-                createdAt: contactSubmission.createdAt,
-            })
-            .from(contactSubmission)
-            .orderBy(desc(contactSubmission.createdAt))
+        const filters = parseContactFilters(request.nextUrl.searchParams)
+        const { contacts } = await getFilteredClassifiedContacts(filters)
 
-        // Generate CSV
         const headers = [
             'ID',
             'Name',
@@ -53,6 +28,9 @@ export async function GET() {
             'Procedure',
             'Preferred Contact Time',
             'Source',
+            'Classified Source',
+            'Classified Medium',
+            'Classification',
             'UTM Source',
             'UTM Medium',
             'UTM Campaign',
@@ -79,6 +57,9 @@ export async function GET() {
             contact.procedure ?? '',
             contact.preferredContactTime ?? '',
             contact.source ?? '',
+            contact.attribution.source,
+            contact.attribution.medium,
+            contact.attribution.classification,
             contact.utmSource ?? '',
             contact.utmMedium ?? '',
             contact.utmCampaign ?? '',

--- a/apps/admin/components/contacts/contacts-filter-bar.component.tsx
+++ b/apps/admin/components/contacts/contacts-filter-bar.component.tsx
@@ -1,0 +1,177 @@
+'use client'
+
+import { useCallback, useMemo, useTransition } from 'react'
+import { usePathname, useRouter, useSearchParams } from 'next/navigation'
+
+import { MultiSelect } from '@workspace/ui/components/multi-select'
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from '@workspace/ui/components/select'
+
+import { CustomDateRangePicker } from '@/components/analytics/leads/custom-date-range-picker.component'
+import {
+    DATE_RANGE_OPTIONS,
+    type DateRangePreset,
+} from '@/lib/types/analytics/date-range.type'
+
+type Props = {
+    sourceOptions: string[]
+    mediumOptions: string[]
+    selectedSources: string[]
+    selectedMediums: string[]
+    dateRangePreset: DateRangePreset
+    startDate: Date
+    endDate: Date
+}
+
+const FILTER_KEYS = ['dateRange', 'startDate', 'endDate', 'sources', 'mediums']
+
+export function ContactsFilterBar({
+    sourceOptions,
+    mediumOptions,
+    selectedSources,
+    selectedMediums,
+    dateRangePreset,
+    startDate,
+    endDate,
+}: Props) {
+    const router = useRouter()
+    const pathname = usePathname()
+    const searchParams = useSearchParams()
+    const [isPending, startTransition] = useTransition()
+
+    const sourceChoices = useMemo(
+        () => sourceOptions.map((v) => ({ label: v, value: v })),
+        [sourceOptions]
+    )
+    const mediumChoices = useMemo(
+        () => mediumOptions.map((v) => ({ label: v, value: v })),
+        [mediumOptions]
+    )
+
+    const updateParams = useCallback(
+        (mutate: (params: URLSearchParams) => void) => {
+            const next = new URLSearchParams(searchParams.toString())
+            mutate(next)
+            // Any filter change resets pagination.
+            next.delete('page')
+            const query = next.toString()
+            const href = query ? `${pathname}?${query}` : pathname
+            startTransition(() => {
+                router.replace(href, { scroll: false })
+            })
+        },
+        [pathname, router, searchParams]
+    )
+
+    const handlePresetChange = (value: string) => {
+        updateParams((params) => {
+            if (value === '28d') {
+                // Default — drop the param so URLs stay clean.
+                params.delete('dateRange')
+            } else {
+                params.set('dateRange', value)
+            }
+            // Custom-only params become stale when switching to a preset.
+            if (value !== 'custom') {
+                params.delete('startDate')
+                params.delete('endDate')
+            } else {
+                // Seed with the current resolved window so the calendar
+                // opens on something sensible.
+                params.set('startDate', startDate.toISOString())
+                params.set('endDate', endDate.toISOString())
+            }
+        })
+    }
+
+    const handleCustomRange = (start: Date, end: Date) => {
+        updateParams((params) => {
+            params.set('dateRange', 'custom')
+            params.set('startDate', start.toISOString())
+            params.set('endDate', end.toISOString())
+        })
+    }
+
+    const handleSourcesChange = (values: string[]) => {
+        updateParams((params) => {
+            params.delete('sources')
+            if (values.length) params.set('sources', values.join(','))
+        })
+    }
+
+    const handleMediumsChange = (values: string[]) => {
+        updateParams((params) => {
+            params.delete('mediums')
+            if (values.length) params.set('mediums', values.join(','))
+        })
+    }
+
+    const hasActiveFilters = FILTER_KEYS.some((key) => searchParams.has(key))
+
+    const handleClearAll = () => {
+        startTransition(() => {
+            router.replace(pathname, { scroll: false })
+        })
+    }
+
+    return (
+        <div
+            className='bg-card flex flex-wrap items-center gap-3 rounded-md border px-4 py-3'
+            data-pending={isPending || undefined}
+        >
+            <Select value={dateRangePreset} onValueChange={handlePresetChange}>
+                <SelectTrigger className='w-[170px]'>
+                    <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                    {DATE_RANGE_OPTIONS.map((opt) => (
+                        <SelectItem key={opt.value} value={opt.value}>
+                            {opt.label}
+                        </SelectItem>
+                    ))}
+                </SelectContent>
+            </Select>
+
+            {dateRangePreset === 'custom' && (
+                <CustomDateRangePicker
+                    startDate={startDate}
+                    endDate={endDate}
+                    onChange={handleCustomRange}
+                />
+            )}
+
+            <MultiSelect
+                options={sourceChoices}
+                value={selectedSources}
+                onValueChange={handleSourcesChange}
+                placeholder='All sources'
+                searchable
+                className='min-w-[200px]'
+            />
+
+            <MultiSelect
+                options={mediumChoices}
+                value={selectedMediums}
+                onValueChange={handleMediumsChange}
+                placeholder='All mediums'
+                searchable
+                className='min-w-[200px]'
+            />
+
+            {hasActiveFilters && (
+                <button
+                    type='button'
+                    onClick={handleClearAll}
+                    className='text-muted-foreground hover:text-foreground ml-auto text-sm underline-offset-4 hover:underline'
+                >
+                    Clear filters
+                </button>
+            )}
+        </div>
+    )
+}

--- a/apps/admin/components/contacts/page-size-select.component.tsx
+++ b/apps/admin/components/contacts/page-size-select.component.tsx
@@ -1,0 +1,68 @@
+'use client'
+
+import { useTransition } from 'react'
+import { usePathname, useRouter, useSearchParams } from 'next/navigation'
+
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from '@workspace/ui/components/select'
+
+import {
+    DEFAULT_PAGE_SIZE,
+    PAGE_SIZE_OPTIONS,
+    type PageSize,
+} from '@/components/contacts/page-size.constants'
+
+type Props = {
+    pageSize: PageSize
+}
+
+export function PageSizeSelect({ pageSize }: Props) {
+    const router = useRouter()
+    const pathname = usePathname()
+    const searchParams = useSearchParams()
+    const [isPending, startTransition] = useTransition()
+
+    const handleChange = (value: string) => {
+        const next = new URLSearchParams(searchParams.toString())
+        const parsed = Number(value) as PageSize
+        if (parsed === DEFAULT_PAGE_SIZE) {
+            next.delete('pageSize')
+        } else {
+            next.set('pageSize', String(parsed))
+        }
+        // Changing page size shifts what the current page number means, so
+        // reset to the first page to avoid landing past the end.
+        next.delete('page')
+        const query = next.toString()
+        const href = query ? `${pathname}?${query}` : pathname
+        startTransition(() => {
+            router.replace(href, { scroll: false })
+        })
+    }
+
+    return (
+        <div
+            className='text-muted-foreground flex items-center gap-2 text-sm'
+            data-pending={isPending || undefined}
+        >
+            <span>Rows per page</span>
+            <Select value={String(pageSize)} onValueChange={handleChange}>
+                <SelectTrigger className='h-8 w-[80px]'>
+                    <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                    {PAGE_SIZE_OPTIONS.map((size) => (
+                        <SelectItem key={size} value={String(size)}>
+                            {size}
+                        </SelectItem>
+                    ))}
+                </SelectContent>
+            </Select>
+        </div>
+    )
+}

--- a/apps/admin/components/contacts/page-size.constants.ts
+++ b/apps/admin/components/contacts/page-size.constants.ts
@@ -1,0 +1,3 @@
+export const PAGE_SIZE_OPTIONS = [10, 25, 50, 100] as const
+export type PageSize = (typeof PAGE_SIZE_OPTIONS)[number]
+export const DEFAULT_PAGE_SIZE: PageSize = 10

--- a/apps/admin/lib/queries/contacts-filters.ts
+++ b/apps/admin/lib/queries/contacts-filters.ts
@@ -1,0 +1,210 @@
+import { classifyLeadAttribution } from '@/lib/analytics/classify-lead-attribution'
+import { getContactsInDateRange } from '@/lib/queries/contacts.query'
+import {
+    DATE_RANGE_OPTIONS,
+    getDateRangeFromPreset,
+    type DateRangePreset,
+} from '@/lib/types/analytics/date-range.type'
+import type {
+    ClassifiedContactListItem,
+    ContactListItem,
+} from '@/lib/types/contacts/contacts.type'
+
+const DEFAULT_PRESET: DateRangePreset = '28d'
+
+/**
+ * Parsed + normalized filter state for the contacts page.
+ *
+ * `dateRangePreset === 'custom'` means `startDate` and `endDate` came from
+ * the `startDate`/`endDate` search params rather than a preset calculation.
+ */
+export type ContactFilters = {
+    dateRangePreset: DateRangePreset
+    startDate: Date
+    endDate: Date
+    sources: string[]
+    mediums: string[]
+}
+
+/**
+ * Accept either the already-resolved plain object from Next.js server
+ * `searchParams`, or a `URLSearchParams` instance (used in route handlers).
+ */
+type SearchParamsInput =
+    | URLSearchParams
+    | Record<string, string | string[] | undefined>
+
+function readParam(input: SearchParamsInput, key: string): string | null {
+    if (input instanceof URLSearchParams) {
+        return input.get(key)
+    }
+    const raw = input[key]
+    if (Array.isArray(raw)) return raw[0] ?? null
+    return raw ?? null
+}
+
+function readParamList(input: SearchParamsInput, key: string): string[] {
+    if (input instanceof URLSearchParams) {
+        // Support both ?k=a&k=b and ?k=a,b.
+        const many = input.getAll(key)
+        if (many.length > 1) return many.flatMap(splitCsv).filter(Boolean)
+        if (many.length === 1) return splitCsv(many[0]!)
+        return []
+    }
+    const raw = input[key]
+    if (Array.isArray(raw)) return raw.flatMap(splitCsv).filter(Boolean)
+    if (typeof raw === 'string') return splitCsv(raw)
+    return []
+}
+
+function splitCsv(value: string): string[] {
+    return value
+        .split(',')
+        .map((s) => s.trim())
+        .filter((s) => s.length > 0)
+}
+
+function isValidPreset(value: string): value is DateRangePreset {
+    return DATE_RANGE_OPTIONS.some((opt) => opt.value === value)
+}
+
+function parseDateParam(raw: string | null): Date | null {
+    if (!raw) return null
+    const parsed = new Date(raw)
+    if (Number.isNaN(parsed.getTime())) return null
+    return parsed
+}
+
+/**
+ * Parse URL search params into a validated `ContactFilters`. Invalid or
+ * missing values fall back to the `28d` preset (matching the leads page
+ * default) so broken bookmarks never render a blank admin screen.
+ */
+export function parseContactFilters(input: SearchParamsInput): ContactFilters {
+    const presetRaw = readParam(input, 'dateRange')
+    const preset: DateRangePreset =
+        presetRaw && isValidPreset(presetRaw) ? presetRaw : DEFAULT_PRESET
+
+    const sources = readParamList(input, 'sources')
+    const mediums = readParamList(input, 'mediums')
+
+    if (preset === 'custom') {
+        const customStart = parseDateParam(readParam(input, 'startDate'))
+        const customEnd = parseDateParam(readParam(input, 'endDate'))
+        if (customStart && customEnd && customStart <= customEnd) {
+            return {
+                dateRangePreset: 'custom',
+                startDate: customStart,
+                endDate: customEnd,
+                sources,
+                mediums,
+            }
+        }
+        // Malformed custom range → fall back to default preset.
+        const fallback = getDateRangeFromPreset(DEFAULT_PRESET)
+        return {
+            dateRangePreset: DEFAULT_PRESET,
+            startDate: fallback.startDate,
+            endDate: fallback.endDate,
+            sources,
+            mediums,
+        }
+    }
+
+    const range = getDateRangeFromPreset(preset)
+    return {
+        dateRangePreset: preset,
+        startDate: range.startDate,
+        endDate: range.endDate,
+        sources,
+        mediums,
+    }
+}
+
+function classifyContact(contact: ContactListItem): ClassifiedContactListItem {
+    const attribution = classifyLeadAttribution({
+        utmSource: contact.utmSource,
+        utmMedium: contact.utmMedium,
+        source: contact.source,
+        referrer: contact.referrer,
+        gclid: contact.gclid,
+        fbclid: contact.fbclid,
+        ttclid: contact.ttclid,
+    })
+    return { ...contact, attribution }
+}
+
+function matchesFilters(
+    row: ClassifiedContactListItem,
+    sources: string[],
+    mediums: string[]
+): boolean {
+    if (sources.length && !sources.includes(row.attribution.source))
+        return false
+    if (mediums.length && !mediums.includes(row.attribution.medium))
+        return false
+    return true
+}
+
+/**
+ * Fetch + classify the full windowed set. Shared primitive used by both the
+ * filtered-only helper and the page-data helper so the DB is only hit once
+ * per request even when both the row set and the option lists are needed.
+ */
+async function fetchAndClassify(
+    filters: ContactFilters
+): Promise<ClassifiedContactListItem[]> {
+    const rows = await getContactsInDateRange(
+        filters.startDate,
+        filters.endDate
+    )
+    return rows.map(classifyContact)
+}
+
+/**
+ * Return only the contacts that match the filter set. Used by the CSV export
+ * route, which doesn't need the dropdown option lists.
+ */
+export async function getFilteredClassifiedContacts(
+    filters: ContactFilters
+): Promise<{ contacts: ClassifiedContactListItem[]; total: number }> {
+    const classified = await fetchAndClassify(filters)
+    const filtered = classified.filter((row) =>
+        matchesFilters(row, filters.sources, filters.mediums)
+    )
+    return { contacts: filtered, total: filtered.length }
+}
+
+/**
+ * Return the filtered rows *and* the dropdown option lists in a single DB
+ * round-trip. Option lists are derived from the unfiltered windowed set and
+ * always union in the user's current selections so active chips remain
+ * removable even after narrowing the range.
+ */
+export async function getContactsPageData(filters: ContactFilters): Promise<{
+    contacts: ClassifiedContactListItem[]
+    total: number
+    sourceOptions: string[]
+    mediumOptions: string[]
+}> {
+    const classified = await fetchAndClassify(filters)
+
+    const sourceSet = new Set<string>(filters.sources)
+    const mediumSet = new Set<string>(filters.mediums)
+    for (const row of classified) {
+        sourceSet.add(row.attribution.source)
+        mediumSet.add(row.attribution.medium)
+    }
+
+    const filtered = classified.filter((row) =>
+        matchesFilters(row, filters.sources, filters.mediums)
+    )
+
+    const sortLocale = (a: string, b: string) => a.localeCompare(b)
+    return {
+        contacts: filtered,
+        total: filtered.length,
+        sourceOptions: [...sourceSet].sort(sortLocale),
+        mediumOptions: [...mediumSet].sort(sortLocale),
+    }
+}

--- a/apps/admin/lib/queries/contacts.query.ts
+++ b/apps/admin/lib/queries/contacts.query.ts
@@ -1,56 +1,52 @@
 import { db } from '@workspace/db/client'
 import { contactSubmission } from '@workspace/db/schema/contact'
-import { count, desc, eq } from 'drizzle-orm'
+import { and, desc, eq, gte, lte } from 'drizzle-orm'
 
 import type { ContactListItem } from '@/lib/types/contacts/contacts.type'
 
-export async function getContacts(
-    page = 1,
-    pageSize = 10
-): Promise<{ contacts: ContactListItem[]; total: number }> {
-    const offset = (page - 1) * pageSize
-
-    const [contacts, totalResult] = await Promise.all([
-        db
-            .select({
-                id: contactSubmission.id,
-                name: contactSubmission.name,
-                firstName: contactSubmission.firstName,
-                lastName: contactSubmission.lastName,
-                email: contactSubmission.email,
-                phone: contactSubmission.phone,
-                subject: contactSubmission.subject,
-                message: contactSubmission.message,
-                procedure: contactSubmission.procedure,
-                source: contactSubmission.source,
-                preferredContactTime: contactSubmission.preferredContactTime,
-                createdAt: contactSubmission.createdAt,
-                // UTM fields
-                utmSource: contactSubmission.utmSource,
-                utmMedium: contactSubmission.utmMedium,
-                utmCampaign: contactSubmission.utmCampaign,
-                utmContent: contactSubmission.utmContent,
-                utmTerm: contactSubmission.utmTerm,
-                // Ad platform IDs
-                gclid: contactSubmission.gclid,
-                fbclid: contactSubmission.fbclid,
-                ttclid: contactSubmission.ttclid,
-                // Other analytics
-                referrer: contactSubmission.referrer,
-                landingPage: contactSubmission.landingPage,
-                ipAddress: contactSubmission.ipAddress,
-            })
-            .from(contactSubmission)
-            .orderBy(desc(contactSubmission.createdAt))
-            .limit(pageSize)
-            .offset(offset),
-        db.select({ count: count() }).from(contactSubmission),
-    ])
-
-    return {
-        contacts,
-        total: totalResult[0]?.count ?? 0,
-    }
+/**
+ * Fetch every contact submission whose `createdAt` falls within the inclusive
+ * [startDate, endDate] window. Returns the full set (no pagination) sorted
+ * newest-first so callers can classify, filter, and paginate in memory.
+ */
+export async function getContactsInDateRange(
+    startDate: Date,
+    endDate: Date
+): Promise<ContactListItem[]> {
+    return db
+        .select({
+            id: contactSubmission.id,
+            name: contactSubmission.name,
+            firstName: contactSubmission.firstName,
+            lastName: contactSubmission.lastName,
+            email: contactSubmission.email,
+            phone: contactSubmission.phone,
+            subject: contactSubmission.subject,
+            message: contactSubmission.message,
+            procedure: contactSubmission.procedure,
+            source: contactSubmission.source,
+            preferredContactTime: contactSubmission.preferredContactTime,
+            createdAt: contactSubmission.createdAt,
+            utmSource: contactSubmission.utmSource,
+            utmMedium: contactSubmission.utmMedium,
+            utmCampaign: contactSubmission.utmCampaign,
+            utmContent: contactSubmission.utmContent,
+            utmTerm: contactSubmission.utmTerm,
+            gclid: contactSubmission.gclid,
+            fbclid: contactSubmission.fbclid,
+            ttclid: contactSubmission.ttclid,
+            referrer: contactSubmission.referrer,
+            landingPage: contactSubmission.landingPage,
+            ipAddress: contactSubmission.ipAddress,
+        })
+        .from(contactSubmission)
+        .where(
+            and(
+                gte(contactSubmission.createdAt, startDate),
+                lte(contactSubmission.createdAt, endDate)
+            )
+        )
+        .orderBy(desc(contactSubmission.createdAt))
 }
 
 export async function getContactById(

--- a/apps/admin/lib/types/contacts/contacts.type.ts
+++ b/apps/admin/lib/types/contacts/contacts.type.ts
@@ -1,3 +1,5 @@
+import type { LeadAttribution } from '@/lib/types/analytics/lead-trends.type'
+
 export type ContactListItem = {
     id: string
     name: string
@@ -22,6 +24,15 @@ export type ContactListItem = {
     landingPage: string | null
     ipAddress: string | null
     createdAt: Date
+}
+
+/**
+ * A ContactListItem with its derived attribution (canonical source/medium
+ * produced by `classifyLeadAttribution`). The attribution is nested to avoid
+ * shadowing the raw `source` column preserved on `ContactListItem`.
+ */
+export type ClassifiedContactListItem = ContactListItem & {
+    attribution: LeadAttribution
 }
 
 export type ContactAnalyticsStats = {


### PR DESCRIPTION
## Summary
- Add classified source/medium multi-selects and preset + custom date-range picker to the admin `/contacts` page (matches `/analytics/leads` semantics; same `classifyLeadAttribution` helper produces values like `google`/`cpc`, `facebook`/`paid`, `referral/<host>`, `direct`, etc.)
- Filter state lives entirely in URL search params (`dateRange`, `startDate`, `endDate`, `sources`, `mediums`, `page`, `pageSize`) so views are shareable, back/forward works, and SSR still drives the page
- CSV export route honors the same filters and now includes `Classified Source`, `Classified Medium`, and `Classification` columns so downloads match what's on screen
- Add a rows-per-page selector (10 / 25 / 50 / 100) persisted via `?pageSize`; changing size resets `page`
- Add an "Attribution" column on the table and an empty-state "Clear filters" action

## Implementation notes
- New `getContactsPageData(filters)` helper fetches the windowed set once and returns both the filtered rows and the dropdown option lists, so the page is one DB round-trip
- Option lists union in the user's current selections so active chips stay removable even after narrowing the date range
- Page-size constants live in a non-client module: Next.js replaces `'use client'` exports with client-reference proxies, which strips array methods like `.includes` when a server component reads them
- Malformed `dateRange` / `startDate` / `endDate` / `pageSize` params silently fall back to defaults (`28d`, `10`) so broken bookmarks never render a blank admin screen
- Orphaned `getContacts()` query removed (no callers after the rewrite)

## Test plan
- [ ] Load `/contacts` — default view is last 28 days with 10 rows per page
- [ ] Open source multi-select — verify values like `google`, `facebook`, `direct`, `referral/<host>`
- [ ] Apply `source=google` and `medium=cpc` — URL updates, table narrows
- [ ] Switch date range to Custom and pick a 7-day window — `startDate`/`endDate` appear in URL
- [ ] Copy URL with active filters to a new tab — same view renders
- [ ] Change rows-per-page to 50 — URL gets `?pageSize=50`, pagination recalculates, `page` resets
- [ ] Pick a range with no results — empty state shows "Clear filters" link
- [ ] Click Export CSV with active filters — download matches visible row count and includes classified columns
- [ ] Compare with `/analytics/leads` filtered by same `source`+`medium`+window — contacts total should be ≤ leads total (contacts is a subset)
- [ ] `pnpm typecheck --filter=admin` and `pnpm lint --filter=admin` pass (verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added advanced filtering system with date-range presets, source and medium multi-select, and clear filters button
  * Added configurable rows-per-page selector (10, 25, 50, or 100 rows)
  * Replaced source column with attribution badges for improved lead classification
  * Enhanced CSV export with additional classified attribution fields
  * Filter state now persists when navigating and exporting data

<!-- end of auto-generated comment: release notes by coderabbit.ai -->