### PR TITLE
fix(attribution): strip foreign click IDs from organic-source leads

### DIFF
--- a/apps/web/app/api/contact/route.ts
+++ b/apps/web/app/api/contact/route.ts
@@ -35,6 +35,7 @@ import {
     sendContactNotification,
 } from '@/lib/services/email.service'
 import { sendLeadToN8N } from '@/lib/services/n8n-webhook.service'
+import { sanitizeAdClickIds } from '@/lib/analytics/sanitize-attribution.util'
 import { siteConfig } from '@/lib/data/site-config'
 import { env } from '@/env'
 
@@ -477,6 +478,11 @@ export async function POST(
         // Extract client IP for analytics
         const clientIP = getClientIP(request)
 
+        // Drop click IDs that don't match the explicit utm_source. Instagram
+        // appends fbclid to every outbound bio-link click, so without this
+        // doctor/influencer/organic-social leads get falsely attributed to Meta.
+        const attribution = sanitizeAdClickIds(validatedData)
+
         const insertData: InsertContactSubmission = {
             name: fullName,
             firstName: validatedData.firstName,
@@ -500,9 +506,9 @@ export async function POST(
             utmCampaign: validatedData.utmCampaign,
             utmContent: validatedData.utmContent,
             utmTerm: validatedData.utmTerm,
-            gclid: validatedData.gclid,
-            fbclid: validatedData.fbclid,
-            ttclid: validatedData.ttclid,
+            gclid: attribution.gclid,
+            fbclid: attribution.fbclid,
+            ttclid: attribution.ttclid,
             referrer: validatedData.referrer,
             landingPage: validatedData.landingPage,
         }

--- a/apps/web/lib/analytics/sanitize-attribution.util.ts
+++ b/apps/web/lib/analytics/sanitize-attribution.util.ts
@@ -1,0 +1,37 @@
+/**
+ * Drop ad-platform click IDs that don't belong to the lead's actual source.
+ *
+ * Instagram's in-app browser auto-appends `fbclid` to every outbound link,
+ * including organic ones (doctor bio links, influencer pages, etc.). Carrying
+ * that `fbclid` through to our DB and CRM lets Meta credit itself for
+ * conversions that came from a non-Meta source.
+ *
+ * Rule: when `utm_source` is explicitly set, keep only the click ID for the
+ * matching platform. When `utm_source` is missing, leave click IDs alone so
+ * direct paid-ad clicks (UTMs stripped, click ID present) still attribute.
+ */
+
+const META_SOURCES = new Set(['facebook', 'fb', 'instagram', 'ig', 'meta'])
+const GOOGLE_SOURCES = new Set(['google', 'google_ads', 'gads', 'adwords'])
+const TIKTOK_SOURCES = new Set(['tiktok', 'tiktok_ads'])
+
+export type AdClickIdAttribution = {
+    utmSource?: string | null | undefined
+    fbclid?: string | null | undefined
+    gclid?: string | null | undefined
+    ttclid?: string | null | undefined
+}
+
+export function sanitizeAdClickIds<T extends AdClickIdAttribution>(
+    input: T
+): T {
+    const utmSource = input.utmSource?.trim().toLowerCase()
+    if (!utmSource) return input
+
+    return {
+        ...input,
+        fbclid: META_SOURCES.has(utmSource) ? input.fbclid : undefined,
+        gclid: GOOGLE_SOURCES.has(utmSource) ? input.gclid : undefined,
+        ttclid: TIKTOK_SOURCES.has(utmSource) ? input.ttclid : undefined,
+    }
+}

--- a/apps/web/lib/analytics/sanitize-attribution.util.ts
+++ b/apps/web/lib/analytics/sanitize-attribution.util.ts
@@ -1,22 +1,38 @@
 /**
  * Drop ad-platform click IDs that don't belong to the lead's actual source.
  *
- * Instagram's in-app browser auto-appends `fbclid` to every outbound link,
- * including organic ones (doctor bio links, influencer pages, etc.). Carrying
- * that `fbclid` through to our DB and CRM lets Meta credit itself for
- * conversions that came from a non-Meta source.
+ * Instagram's in-app browser auto-appends `fbclid` to every outbound link —
+ * organic bio links (doctors, influencers, our own /ig and /fb redirects)
+ * included. Carrying that `fbclid` through to our DB and CRM lets Meta credit
+ * itself for conversions that came from a non-paid source.
  *
- * Rule: when `utm_source` is explicitly set, keep only the click ID for the
- * matching platform. When `utm_source` is missing, leave click IDs alone so
- * direct paid-ad clicks (UTMs stripped, click ID present) still attribute.
+ * Rule: keep a platform's click ID only when both
+ *   1. `utm_source` belongs to that platform's family, AND
+ *   2. `utm_medium` indicates paid traffic (cpc / paid / paid-social / …).
+ *
+ * If `utm_source` is missing entirely, click IDs are left alone so direct
+ * paid-ad clicks where UTMs were stripped still attribute correctly.
  */
 
 const META_SOURCES = new Set(['facebook', 'fb', 'instagram', 'ig', 'meta'])
 const GOOGLE_SOURCES = new Set(['google', 'google_ads', 'gads', 'adwords'])
 const TIKTOK_SOURCES = new Set(['tiktok', 'tiktok_ads'])
 
+const PAID_MEDIUMS = new Set([
+    'cpc',
+    'ppc',
+    'paid',
+    'paid-social',
+    'paid_social',
+    'paidsocial',
+    'ads',
+    'sponsored',
+    'display',
+])
+
 export type AdClickIdAttribution = {
     utmSource?: string | null | undefined
+    utmMedium?: string | null | undefined
     fbclid?: string | null | undefined
     gclid?: string | null | undefined
     ttclid?: string | null | undefined
@@ -28,10 +44,16 @@ export function sanitizeAdClickIds<T extends AdClickIdAttribution>(
     const utmSource = input.utmSource?.trim().toLowerCase()
     if (!utmSource) return input
 
+    const utmMedium = input.utmMedium?.trim().toLowerCase()
+    const isPaid = !!utmMedium && PAID_MEDIUMS.has(utmMedium)
+
     return {
         ...input,
-        fbclid: META_SOURCES.has(utmSource) ? input.fbclid : undefined,
-        gclid: GOOGLE_SOURCES.has(utmSource) ? input.gclid : undefined,
-        ttclid: TIKTOK_SOURCES.has(utmSource) ? input.ttclid : undefined,
+        fbclid:
+            isPaid && META_SOURCES.has(utmSource) ? input.fbclid : undefined,
+        gclid:
+            isPaid && GOOGLE_SOURCES.has(utmSource) ? input.gclid : undefined,
+        ttclid:
+            isPaid && TIKTOK_SOURCES.has(utmSource) ? input.ttclid : undefined,
     }
 }


### PR DESCRIPTION
## Summary

- Doctor / influencer / organic-bio-link leads were being attributed to Meta Ads because Instagram's in-app browser auto-appends `fbclid` to every outbound click. The `fbclid` then flowed through our 308 redirects (`/dr-karlinsky-ig`, `/melany`, `/yele`, `/lorena-gonzalez`, `/melany-capote`, `/cristina-deletto`, `/ig`, `/fb`, `/tiktok`) into the lead, the DB, and the N8N → Meta CAPI pipeline.
- New utility `sanitizeAdClickIds()` (`apps/web/lib/analytics/sanitize-attribution.util.ts`) drops `fbclid` / `gclid` / `ttclid` whose platform doesn't match the explicit `utm_source` + `utm_medium`. Wired into the contact ingest layer (`apps/web/app/api/contact/route.ts`).
- A click ID is kept only when `utm_source` belongs to that platform's family **and** `utm_medium` indicates paid traffic (`cpc` / `paid` / `paid-social` / `ppc` / `ads` / `sponsored` / `display`). Click IDs without any `utm_source` are left alone so direct paid-ad clicks still attribute.

### Cases handled

| `utm_source` | `utm_medium` | `fbclid` kept? |
|---|---|---|
| (none) | — | yes (direct paid-ad fallback) |
| `facebook` / `instagram` / `meta` | `cpc` / `paid` / `paid-social` / … | yes |
| `facebook` / `instagram` | `social` (our `/fb`, `/ig` bio links) | **no** |
| `doctor` / `influencer` / etc. | anything | **no** |

Same rule applies to `gclid` (Google) and `ttclid` (TikTok).

### Caveat

Manual paid Meta campaigns that set `utm_source=facebook` without `utm_medium` (or with a non-paid medium) will have their `fbclid` stripped. Meta auto-tagging defaults to `utm_medium=paid`, so this should be a non-issue in practice — but worth flagging.

### Out of scope

- Existing rows in `contact_submission` still have stale `fbclid` values. Backfill (`UPDATE contact_submission SET fbclid = NULL WHERE …`) can be run separately if desired.
- Page-view analytics (`/api/analytics/page-view`) is untouched — the user's report was about leads, not page views.

## Test plan

- [ ] `pnpm --filter web typecheck` passes (verified locally)
- [ ] `pnpm --filter web lint` passes (verified locally)
- [ ] Submit a form on `/miami-plastic-surgery-specials?utm_source=doctor&utm_medium=dr-karlinsky&fbclid=test123` → confirm `fbclid` is `null` in `contact_submission` and absent from the N8N payload
- [ ] Submit a form on `/miami-plastic-surgery-specials?utm_source=facebook&utm_medium=cpc&fbclid=test123` → confirm `fbclid` is preserved (paid Meta path still works)
- [ ] Submit a form on `/miami-plastic-surgery-specials?fbclid=test123` (no UTMs) → confirm `fbclid` is preserved (direct paid-ad fallback)
- [ ] In the admin contacts list, a doctor-source lead should no longer show the **Meta** badge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced contact form submission handling to properly validate and sanitize advertising attribution parameters for more accurate tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->