### PR TITLE
feat(landing): Dr. Victoria Karlinsky lead-conversion landing page

### DIFF
--- a/apps/web/app/dr-victoria-karlinsky/page.tsx
+++ b/apps/web/app/dr-victoria-karlinsky/page.tsx
@@ -1,0 +1,264 @@
+/**
+ * Dr. Victoria Karlinsky — Lead Conversion Landing Page
+ *
+ * Dedicated landing page for paid ad traffic targeting Dr. Karlinsky's name
+ * and high-intent organic searches. Conversion-optimized: every section drives
+ * toward the hero ConsultationForm (#hero-form).
+ *
+ * URL: /dr-victoria-karlinsky
+ * Distinct from the existing /dr-karlinsky bio page (slug-based) so paid
+ * traffic and organic discovery stay separate.
+ */
+import {
+    FAQSchema,
+    PhysicianSchema,
+    ServiceSchema,
+    WebPageSchema,
+} from '@workspace/seo/react'
+
+import { ContainerLayout } from '@/components/container-layout.component'
+import { DrKarlinskyAbout } from '@/components/dr-karlinsky-landing/dr-karlinsky-about.component'
+import { DrKarlinskyCredentialsWall } from '@/components/dr-karlinsky-landing/dr-karlinsky-credentials-wall.component'
+import { DrKarlinskyHero } from '@/components/dr-karlinsky-landing/dr-karlinsky-hero.component'
+import { DrKarlinskySpecialties } from '@/components/dr-karlinsky-landing/dr-karlinsky-specialties.component'
+import { DrKarlinskyTrustStrip } from '@/components/dr-karlinsky-landing/dr-karlinsky-trust-strip.component'
+import { DrKarlinskyWhyChoose } from '@/components/dr-karlinsky-landing/dr-karlinsky-why-choose.component'
+import { ExitIntentPopup } from '@/components/home/exit-intent-popup.component'
+import { MiniLeadCapture } from '@/components/landing/mini-lead-capture.component'
+import { CTASection } from '@/components/shared/cta-section.component'
+import { CategorizedFAQ } from '@/components/shared/faq-categorized.component'
+import { GalleryCarousel } from '@/components/shared/gallery-carousel.component'
+import { GoogleReviews } from '@/components/shared/google-reviews.component'
+import { WeeklyPayments } from '@/components/shared/weekly-payments.component'
+import {
+    drKarlinskyFaqCategories,
+    drKarlinskyFaqConfig,
+    drKarlinskyFaqData,
+} from '@/lib/data/faq/dr-karlinsky-faq.data'
+import { siteConfig } from '@/lib/data/site-config'
+import { surgeons } from '@/lib/data/surgeons/surgeons-data'
+import { getSpecialsFeaturedGalleryImages } from '@/lib/queries/gallery/specials-gallery.query'
+import { seoConfig } from '@/lib/seo-config'
+import { toNextMetadata } from '@/lib/seo/metadata'
+import { CONTACT_SOURCES } from '@/lib/types/forms/contact-form.type'
+
+const HERO_FORM_ANCHOR = '#hero-form'
+const PAGE_PATH = '/dr-victoria-karlinsky'
+const PAGE_URL = `${seoConfig.siteUrl}${PAGE_PATH}`
+
+export const metadata = toNextMetadata(seoConfig, {
+    canonical: PAGE_PATH,
+    title: 'Dr. Victoria Karlinsky | Triple Board-Certified Miami Surgeon',
+    description:
+        'Meet Dr. Victoria Karlinsky — triple board-certified cosmetic surgeon and FACS Fellow in Miami. BBL, mommy makeover, tummy tuck, breast & facial surgery. Free consult. Financing from $27/week.',
+
+    openGraph: {
+        title: 'Dr. Victoria Karlinsky | Triple Board-Certified Miami Surgeon',
+        description:
+            'Meet Dr. Victoria Karlinsky — triple board-certified cosmetic surgeon in Miami. Triple board-certified, FACS Fellow, fellowship director. Book your free consultation.',
+        url: PAGE_URL,
+        type: 'profile',
+        siteName: seoConfig.siteName,
+        images: [
+            {
+                url: `${seoConfig.siteUrl}/og-image.jpg`,
+                width: 1200,
+                height: 630,
+                alt: `Dr. Victoria Karlinsky - ${siteConfig.business.name} Miami`,
+            },
+        ],
+    },
+
+    twitter: {
+        card: 'summary_large_image',
+        title: 'Dr. Victoria Karlinsky | Miami Cosmetic Surgeon',
+        description:
+            'Triple board-certified. FACS Fellow. Now booking complimentary consultations in Miami.',
+        images: [`${seoConfig.siteUrl}/og-image.jpg`],
+    },
+
+    alternates: {
+        canonical: PAGE_PATH,
+    },
+})
+
+export default async function DrVictoriaKarlinskyLandingPage() {
+    const surgeon = surgeons[0]
+    const galleryImages = await getSpecialsFeaturedGalleryImages()
+
+    const allFaqItems = Object.values(drKarlinskyFaqData).flat()
+    const faqSchemaItems = allFaqItems.map((faq) => ({
+        question: faq.question,
+        answer: faq.answer,
+    }))
+
+    const sameAsLinks = surgeon
+        ? [
+              ...Object.values(surgeon.social ?? {}).filter((v): v is string =>
+                  Boolean(v)
+              ),
+              ...Object.values(surgeon.externalProfiles ?? {}).filter(
+                  (v): v is string => Boolean(v)
+              ),
+          ]
+        : []
+
+    const phoneTel = siteConfig.contact.phone.replace(/\D/g, '')
+
+    return (
+        <>
+            {/* Page schema */}
+            <WebPageSchema
+                name={`Dr. Victoria Karlinsky - ${siteConfig.business.name}`}
+                url={PAGE_URL}
+                description='Meet Dr. Victoria Karlinsky, triple board-certified cosmetic surgeon at Alluring Plastic Surgery Miami. Book a complimentary consultation.'
+            />
+
+            <FAQSchema items={faqSchemaItems} />
+
+            <ServiceSchema
+                name='Cosmetic Surgery Consultation with Dr. Victoria Karlinsky'
+                description='Complimentary, no-obligation consultation with triple board-certified cosmetic surgeon Dr. Victoria Karlinsky. Discuss BBL, mommy makeover, tummy tuck, breast surgery, facelift, and more.'
+                url={PAGE_URL}
+                serviceType='Cosmetic Surgery Consultation'
+                provider={{
+                    '@id': `${seoConfig.siteUrl}/#organization`,
+                    name: siteConfig.business.name,
+                    url: seoConfig.siteUrl,
+                    type: 'MedicalBusiness',
+                    logo: seoConfig.organization?.logo,
+                }}
+                areaServed={['Miami', 'Florida', 'Latin America', 'Caribbean']}
+                availableLanguage={['English', 'Spanish']}
+                offers={{
+                    price: 0,
+                    priceCurrency: 'USD',
+                    availability: 'InStock',
+                    url: PAGE_URL,
+                }}
+                image={`${seoConfig.siteUrl}/og-image.jpg`}
+            />
+
+            {/* Physician schema (E-E-A-T) */}
+            {surgeon && (
+                <PhysicianSchema
+                    id={`${seoConfig.siteUrl}/#physician-${surgeon.slug}`}
+                    name={surgeon.name}
+                    url={PAGE_URL}
+                    image={
+                        surgeon.images.featured.startsWith('http')
+                            ? surgeon.images.featured
+                            : `${seoConfig.siteUrl}${surgeon.images.featured}`
+                    }
+                    description={surgeon.fullBio}
+                    jobTitle={surgeon.title}
+                    medicalSpecialty={surgeon.specialties}
+                    award={surgeon.certifications}
+                    alumniOf={surgeon.education.map((edu) => ({ name: edu }))}
+                    worksFor={{
+                        '@id': `${seoConfig.siteUrl}/#organization`,
+                        name: siteConfig.business.name,
+                        url: seoConfig.siteUrl,
+                        address: {
+                            streetAddress: siteConfig.contact.address,
+                            addressLocality: siteConfig.contact.city,
+                            addressRegion: siteConfig.contact.state,
+                            postalCode: siteConfig.contact.postalCode,
+                            addressCountry: siteConfig.contact.country,
+                        },
+                    }}
+                    address={{
+                        streetAddress: siteConfig.contact.address,
+                        addressLocality: siteConfig.contact.city,
+                        addressRegion: siteConfig.contact.state,
+                        postalCode: siteConfig.contact.postalCode,
+                        addressCountry: siteConfig.contact.country,
+                    }}
+                    telephone={siteConfig.contact.phone}
+                    sameAs={sameAsLinks}
+                    knowsAbout={surgeon.specialties}
+                />
+            )}
+
+            {/* Page content */}
+            <ContainerLayout as='main' noPaddingTop noPadding size='full'>
+                <DrKarlinskyHero id='hero' />
+
+                <DrKarlinskyTrustStrip id='trust-strip' />
+
+                <DrKarlinskyAbout
+                    id='about-doctor'
+                    formAnchor={HERO_FORM_ANCHOR}
+                />
+
+                <DrKarlinskyWhyChoose
+                    id='why-dr-karlinsky'
+                    formAnchor={HERO_FORM_ANCHOR}
+                />
+
+                <DrKarlinskySpecialties
+                    id='specialties'
+                    formAnchor={HERO_FORM_ANCHOR}
+                />
+
+                <MiniLeadCapture
+                    id='mini-capture'
+                    source={CONTACT_SOURCES.DR_KARLINSKY_LANDING}
+                    analyticsFormName='dr_karlinsky_mini_capture'
+                />
+
+                <GalleryCarousel id='gallery' images={galleryImages} />
+
+                <GoogleReviews
+                    title='Patients on Dr. Karlinsky'
+                    subtitle='Verified Google reviews from real patients'
+                    limit={3}
+                    includeSchema={false}
+                />
+
+                <DrKarlinskyCredentialsWall id='credentials' />
+
+                <WeeklyPayments id='financing' formAnchor={HERO_FORM_ANCHOR} />
+
+                <CategorizedFAQ
+                    id='faq'
+                    categories={drKarlinskyFaqCategories}
+                    faqData={drKarlinskyFaqData}
+                    badge={drKarlinskyFaqConfig.badge}
+                    title={drKarlinskyFaqConfig.title}
+                    subtitle={drKarlinskyFaqConfig.subtitle}
+                    description={drKarlinskyFaqConfig.description}
+                    variant='default'
+                    showBackgroundDecoration={true}
+                    includeSchema={false}
+                    ctaConfig={{
+                        title: 'Still have questions?',
+                        description:
+                            'Our patient concierge is happy to talk it through — no pressure, just honest answers.',
+                        buttonText: 'Call Now',
+                        phoneNumber: phoneTel,
+                    }}
+                />
+
+                <CTASection
+                    id='final-cta'
+                    variant='luxury'
+                    eyebrow='Take the First Step'
+                    heading='Ready to meet Dr. Karlinsky?'
+                    description='Triple board-certified. FACS Fellow. Fellowship Director. Now booking complimentary consultations in Miami — virtual or in-person.'
+                    primaryButton={{
+                        text: 'Book My Free Consultation',
+                        href: HERO_FORM_ANCHOR,
+                    }}
+                    secondaryButton={{
+                        text: `Call ${siteConfig.contact.phoneDisplay}`,
+                        href: `tel:${phoneTel}`,
+                    }}
+                    size='lg'
+                />
+            </ContainerLayout>
+
+            <ExitIntentPopup />
+        </>
+    )
+}

--- a/apps/web/app/dr-victoria-karlinsky/page.tsx
+++ b/apps/web/app/dr-victoria-karlinsky/page.tsx
@@ -20,10 +20,11 @@ import { ContainerLayout } from '@/components/container-layout.component'
 import { DrKarlinskyAbout } from '@/components/dr-karlinsky-landing/dr-karlinsky-about.component'
 import { DrKarlinskyCredentialsWall } from '@/components/dr-karlinsky-landing/dr-karlinsky-credentials-wall.component'
 import { DrKarlinskyHero } from '@/components/dr-karlinsky-landing/dr-karlinsky-hero.component'
+import { DrKarlinskyMinimalFooter } from '@/components/dr-karlinsky-landing/dr-karlinsky-minimal-footer.component'
+import { DrKarlinskyMinimalHeader } from '@/components/dr-karlinsky-landing/dr-karlinsky-minimal-header.component'
 import { DrKarlinskySpecialties } from '@/components/dr-karlinsky-landing/dr-karlinsky-specialties.component'
 import { DrKarlinskyTrustStrip } from '@/components/dr-karlinsky-landing/dr-karlinsky-trust-strip.component'
 import { DrKarlinskyWhyChoose } from '@/components/dr-karlinsky-landing/dr-karlinsky-why-choose.component'
-import { ExitIntentPopup } from '@/components/home/exit-intent-popup.component'
 import { MiniLeadCapture } from '@/components/landing/mini-lead-capture.component'
 import { CTASection } from '@/components/shared/cta-section.component'
 import { CategorizedFAQ } from '@/components/shared/faq-categorized.component'
@@ -180,6 +181,9 @@ export default async function DrVictoriaKarlinskyLandingPage() {
                 />
             )}
 
+            {/* Stripped chrome — no nav exits, just logo + phone + book CTA */}
+            <DrKarlinskyMinimalHeader formAnchor={HERO_FORM_ANCHOR} />
+
             {/* Page content */}
             <ContainerLayout as='main' noPaddingTop noPadding size='full'>
                 <DrKarlinskyHero id='hero' />
@@ -213,6 +217,8 @@ export default async function DrVictoriaKarlinskyLandingPage() {
                     title='Patients on Dr. Karlinsky'
                     subtitle='Verified Google reviews from real patients'
                     limit={3}
+                    showGoogleLink={false}
+                    showViewAllButton={false}
                     includeSchema={false}
                 />
 
@@ -258,7 +264,7 @@ export default async function DrVictoriaKarlinskyLandingPage() {
                 />
             </ContainerLayout>
 
-            <ExitIntentPopup />
+            <DrKarlinskyMinimalFooter />
         </>
     )
 }

--- a/apps/web/app/landing/dr-victoria-karlinsky/page.tsx
+++ b/apps/web/app/landing/dr-victoria-karlinsky/page.tsx
@@ -5,8 +5,10 @@
  * and high-intent organic searches. Conversion-optimized: every section drives
  * toward the hero ConsultationForm (#hero-form).
  *
- * URL: /dr-victoria-karlinsky
- * Distinct from the existing /dr-karlinsky bio page (slug-based) so paid
+ * URL: /landing/dr-victoria-karlinsky
+ * Lives under /landing/* so the global header/footer are auto-stripped via
+ * STANDALONE_ROUTES, and so future ad LPs share the same namespace and chrome
+ * treatment. Distinct from /dr-karlinsky (the canonical bio page) so paid
  * traffic and organic discovery stay separate.
  */
 import {
@@ -44,7 +46,7 @@ import { toNextMetadata } from '@/lib/seo/metadata'
 import { CONTACT_SOURCES } from '@/lib/types/forms/contact-form.type'
 
 const HERO_FORM_ANCHOR = '#hero-form'
-const PAGE_PATH = '/dr-victoria-karlinsky'
+const PAGE_PATH = '/landing/dr-victoria-karlinsky'
 const PAGE_URL = `${seoConfig.siteUrl}${PAGE_PATH}`
 
 export const metadata = toNextMetadata(seoConfig, {

--- a/apps/web/components/dr-karlinsky-landing/dr-karlinsky-about.component.tsx
+++ b/apps/web/components/dr-karlinsky-landing/dr-karlinsky-about.component.tsx
@@ -1,0 +1,159 @@
+/**
+ * DrKarlinskyAbout
+ *
+ * Magazine-style bio block. Portrait + serif body copy + education timeline.
+ * Includes an inline secondary CTA back to the hero form so visitors who
+ * read all the way through her story can convert without scrolling further.
+ */
+import { Button } from '@workspace/ui/components/button'
+import { ArrowRight, GraduationCap, Sparkles } from 'lucide-react'
+import Image from 'next/image'
+import Link from 'next/link'
+
+import { ContentWrapper } from '@/components/shared/content-wrapper.component'
+import { SectionContainer } from '@/components/shared/section-container.component'
+import { surgeons } from '@/lib/data/surgeons/surgeons-data'
+
+export type DrKarlinskyAboutProps = {
+    readonly id?: string
+    readonly formAnchor?: string
+}
+
+export function DrKarlinskyAbout({
+    id = 'about-doctor',
+    formAnchor = '#hero-form',
+}: DrKarlinskyAboutProps) {
+    const surgeon = surgeons[0]
+    if (!surgeon) {
+        return null
+    }
+
+    const firstName = surgeon.name.replace(/^Dr\.\s+/, '').split(' ')[0]
+    const paragraphs = surgeon.fullBio.split('\n\n').filter(Boolean)
+
+    return (
+        <SectionContainer
+            id={id}
+            variant='default'
+            className='relative overflow-hidden bg-white'
+            paddingY='py-20 lg:py-28'
+        >
+            {/* Decorative oversize last name */}
+            <div
+                aria-hidden='true'
+                className='pointer-events-none absolute top-12 -left-6 font-serif text-[18vw] leading-none whitespace-nowrap text-stone-100/70 select-none lg:-left-10'
+            >
+                Karlinsky
+            </div>
+
+            <ContentWrapper
+                size='xl'
+                paddingX='px-6 md:px-12'
+                className='relative z-10'
+            >
+                <div className='grid gap-12 lg:grid-cols-12 lg:gap-16'>
+                    {/* Portrait + sticky philosophy */}
+                    <div className='lg:col-span-5'>
+                        <div className='lg:sticky lg:top-32'>
+                            <div className='relative'>
+                                <div className='ring-gold-500/15 relative aspect-[4/5] w-full overflow-hidden rounded-2xl shadow-xl ring-1 shadow-stone-300/50'>
+                                    <Image
+                                        src={surgeon.images.portrait}
+                                        alt={`Portrait of ${surgeon.name}`}
+                                        fill
+                                        sizes='(min-width: 1024px) 460px, 100vw'
+                                        className='object-cover object-top'
+                                    />
+                                </div>
+                                {/* Floating credential card */}
+                                <div className='ring-gold-500/15 absolute -right-3 -bottom-6 max-w-[220px] rounded-xl bg-white/90 p-4 shadow-2xl ring-1 shadow-stone-900/15 backdrop-blur-xl md:-right-6'>
+                                    <div className='flex items-start gap-3'>
+                                        <div className='from-gold-500 to-gold-300 flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-gradient-to-br shadow-md'>
+                                            <Sparkles className='h-5 w-5 text-stone-950' />
+                                        </div>
+                                        <div>
+                                            <p className='text-gold-600 text-[10px] font-bold tracking-[0.18em] uppercase'>
+                                                Recognized
+                                            </p>
+                                            <p className='mt-1 font-serif text-sm leading-snug font-semibold text-stone-900'>
+                                                Healthgrades & RealSelf featured
+                                                surgeon
+                                            </p>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+
+                    {/* Bio + education + CTA */}
+                    <div className='lg:col-span-7 lg:pt-6'>
+                        <div className='text-gold-600 mb-4 text-xs font-bold tracking-[0.22em] uppercase'>
+                            About Dr. {firstName}
+                        </div>
+                        <h2 className='mb-8 font-serif text-3xl leading-tight text-stone-900 md:text-4xl lg:text-5xl'>
+                            A surgeon&apos;s precision.{' '}
+                            <span className='text-gold-600 italic'>
+                                An artist&apos;s eye.
+                            </span>
+                        </h2>
+
+                        <div className='space-y-5 text-lg leading-relaxed font-light text-stone-600'>
+                            {paragraphs.map((paragraph, index) => (
+                                <p key={index}>{paragraph}</p>
+                            ))}
+                        </div>
+
+                        {surgeon.philosophy && (
+                            <blockquote className='border-gold-500 my-10 border-l-2 pl-6'>
+                                <p className='font-serif text-xl leading-relaxed text-stone-800 italic md:text-2xl'>
+                                    {surgeon.philosophy}
+                                </p>
+                            </blockquote>
+                        )}
+
+                        {/* Education timeline */}
+                        <div className='ring-gold-500/10 mt-10 rounded-2xl bg-stone-50 p-6 ring-1 md:p-8'>
+                            <div className='mb-5 flex items-center gap-3'>
+                                <span className='from-gold-500 to-gold-300 inline-flex h-10 w-10 items-center justify-center rounded-lg bg-gradient-to-br shadow-md'>
+                                    <GraduationCap className='h-5 w-5 text-stone-950' />
+                                </span>
+                                <h3 className='font-serif text-2xl text-stone-900'>
+                                    Training & Education
+                                </h3>
+                            </div>
+                            <ol className='relative space-y-5 border-l border-stone-200 pl-6'>
+                                {surgeon.education.map((edu) => (
+                                    <li
+                                        key={edu}
+                                        className='relative leading-relaxed text-stone-700'
+                                    >
+                                        <span className='ring-gold-200 bg-gold-500 absolute top-1.5 -left-[1.65rem] h-2.5 w-2.5 rounded-full ring-4' />
+                                        {edu}
+                                    </li>
+                                ))}
+                            </ol>
+                        </div>
+
+                        {/* Inline CTA */}
+                        <div className='mt-10 flex flex-col items-start gap-4 sm:flex-row sm:items-center'>
+                            <Button
+                                asChild
+                                size='lg'
+                                className='bg-gold-500 hover:bg-gold-600 group h-auto px-7 py-4 text-base font-bold tracking-wide text-white uppercase shadow-lg shadow-amber-500/30 transition-all hover:shadow-xl hover:shadow-amber-500/40'
+                            >
+                                <Link href={formAnchor}>
+                                    Book With Dr. {firstName}
+                                    <ArrowRight className='ml-1 h-4 w-4 transition-transform group-hover:translate-x-1' />
+                                </Link>
+                            </Button>
+                            <p className='text-sm text-stone-500'>
+                                Complimentary, confidential, no obligation.
+                            </p>
+                        </div>
+                    </div>
+                </div>
+            </ContentWrapper>
+        </SectionContainer>
+    )
+}

--- a/apps/web/components/dr-karlinsky-landing/dr-karlinsky-credentials-wall.component.tsx
+++ b/apps/web/components/dr-karlinsky-landing/dr-karlinsky-credentials-wall.component.tsx
@@ -1,0 +1,158 @@
+/**
+ * DrKarlinskyCredentialsWall
+ *
+ * Heavyweight E-E-A-T section. Splits into:
+ *   1) A wall of all 6 board/fellowship badges with their full names.
+ *   2) Two "verified profile" cards linking to Healthgrades & RealSelf
+ *      (the externalProfiles drive PhysicianSchema sameAs as well).
+ */
+import { ExternalLink, ShieldCheck } from 'lucide-react'
+import Image from 'next/image'
+
+import { ContentWrapper } from '@/components/shared/content-wrapper.component'
+import { SectionContainer } from '@/components/shared/section-container.component'
+import { surgeons } from '@/lib/data/surgeons/surgeons-data'
+
+type ExternalProfileCard = {
+    readonly key: string
+    readonly platform: string
+    readonly tagline: string
+    readonly url: string
+}
+
+export type DrKarlinskyCredentialsWallProps = {
+    readonly id?: string
+}
+
+export function DrKarlinskyCredentialsWall({
+    id = 'credentials',
+}: DrKarlinskyCredentialsWallProps) {
+    const surgeon = surgeons[0]
+    if (!surgeon) {
+        return null
+    }
+
+    const badges = surgeon.certificationBadges ?? []
+    const certifications = surgeon.certifications
+
+    const externalCards: ExternalProfileCard[] = []
+    if (surgeon.externalProfiles?.healthgrades) {
+        externalCards.push({
+            key: 'healthgrades',
+            platform: 'Healthgrades',
+            tagline: 'Verified physician profile & patient reviews',
+            url: surgeon.externalProfiles.healthgrades,
+        })
+    }
+    if (surgeon.externalProfiles?.realself) {
+        externalCards.push({
+            key: 'realself',
+            platform: 'RealSelf',
+            tagline: 'Featured cosmetic surgeon profile & Q&A',
+            url: surgeon.externalProfiles.realself,
+        })
+    }
+
+    return (
+        <SectionContainer
+            id={id}
+            variant='default'
+            className='relative overflow-hidden bg-stone-950'
+            paddingY='py-20 lg:py-28'
+        >
+            {/* Subtle gold ambient */}
+            <div className='pointer-events-none absolute inset-0'>
+                <div className='absolute inset-0 bg-[radial-gradient(ellipse_at_top,_rgba(212,175,55,0.12),_transparent_60%)]' />
+                <div className='bg-gold-500/10 absolute -top-1/4 left-1/3 h-[500px] w-[500px] rounded-full blur-3xl' />
+            </div>
+
+            <ContentWrapper
+                size='xl'
+                paddingX='px-6 md:px-12'
+                className='relative z-10'
+            >
+                <div className='mx-auto mb-14 max-w-3xl text-center lg:mb-16'>
+                    <p className='text-gold-400 mb-3 text-xs font-bold tracking-[0.22em] uppercase'>
+                        The Receipts
+                    </p>
+                    <h2 className='font-serif text-3xl leading-tight text-white md:text-4xl lg:text-5xl'>
+                        Verified credentials.{' '}
+                        <span className='text-gold-300 italic'>
+                            Not just claims.
+                        </span>
+                    </h2>
+                    <p className='mt-4 text-base leading-relaxed text-stone-300 lg:text-lg'>
+                        Six board certifications and fellowships. Two
+                        independent physician directories. Look us up —
+                        we&apos;ll wait.
+                    </p>
+                </div>
+
+                {/* Badge wall */}
+                {badges.length > 0 && (
+                    <div className='mb-12 grid grid-cols-2 gap-4 md:grid-cols-3 lg:grid-cols-6'>
+                        {badges.map((badge, index) => {
+                            const certName = certifications[index] ?? badge.alt
+                            return (
+                                <div
+                                    key={badge.alt}
+                                    className='ring-gold-500/15 group flex flex-col items-center gap-3 rounded-2xl bg-white/5 p-5 ring-1 backdrop-blur-md transition-all duration-300 hover:bg-white/[0.08]'
+                                >
+                                    <div className='flex h-20 w-20 items-center justify-center rounded-xl bg-white p-2.5 shadow-lg shadow-stone-950/40'>
+                                        <Image
+                                            src={badge.src}
+                                            alt={badge.alt}
+                                            width={80}
+                                            height={80}
+                                            className='h-full w-auto object-contain'
+                                        />
+                                    </div>
+                                    <p className='text-center text-[11px] leading-snug font-medium text-stone-300'>
+                                        {certName}
+                                    </p>
+                                </div>
+                            )
+                        })}
+                    </div>
+                )}
+
+                {/* External profile cards */}
+                {externalCards.length > 0 && (
+                    <div>
+                        <div className='mb-6 flex items-center justify-center gap-3'>
+                            <ShieldCheck className='text-gold-400 h-5 w-5' />
+                            <p className='text-gold-300 text-sm font-semibold tracking-[0.18em] uppercase'>
+                                Independently Verified
+                            </p>
+                            <ShieldCheck className='text-gold-400 h-5 w-5' />
+                        </div>
+                        <div className='mx-auto grid max-w-3xl gap-4 sm:grid-cols-2'>
+                            {externalCards.map((card) => (
+                                <a
+                                    key={card.key}
+                                    href={card.url}
+                                    target='_blank'
+                                    rel='noopener noreferrer nofollow'
+                                    className='ring-gold-500/20 hover:ring-gold-400/60 group flex items-center justify-between gap-4 rounded-xl bg-white/[0.04] p-5 ring-1 backdrop-blur-md transition-all duration-300 hover:bg-white/[0.08]'
+                                >
+                                    <div>
+                                        <p className='text-gold-300 text-xs font-semibold tracking-wide uppercase'>
+                                            View on
+                                        </p>
+                                        <p className='mt-1 font-serif text-2xl text-white'>
+                                            {card.platform}
+                                        </p>
+                                        <p className='mt-1 text-sm text-stone-400'>
+                                            {card.tagline}
+                                        </p>
+                                    </div>
+                                    <ExternalLink className='text-gold-400 group-hover:text-gold-300 h-5 w-5 shrink-0 transition-transform group-hover:translate-x-0.5 group-hover:-translate-y-0.5' />
+                                </a>
+                            ))}
+                        </div>
+                    </div>
+                )}
+            </ContentWrapper>
+        </SectionContainer>
+    )
+}

--- a/apps/web/components/dr-karlinsky-landing/dr-karlinsky-hero.component.tsx
+++ b/apps/web/components/dr-karlinsky-landing/dr-karlinsky-hero.component.tsx
@@ -1,0 +1,198 @@
+/**
+ * DrKarlinskyHero
+ *
+ * Lead-conversion hero for Dr. Victoria Karlinsky's landing page.
+ *
+ * Layout: portrait + authority on the left, ConsultationForm on the right.
+ * Mobile stacks form-first (above the fold) with portrait moving below the
+ * headline so the call-to-action stays one tap away.
+ */
+import {
+    Award,
+    BadgeCheck,
+    Languages,
+    MapPin,
+    Quote,
+    ShieldCheck,
+} from 'lucide-react'
+import Image from 'next/image'
+
+import { ConsultationForm } from '@/components/shared/forms/consultation-form.component'
+import { surgeons } from '@/lib/data/surgeons/surgeons-data'
+import { CONTACT_SOURCES } from '@/lib/types/forms/contact-form.type'
+
+const HERO_FORM_ID = 'hero-form'
+
+const TRUST_PILLS = [
+    { icon: BadgeCheck, label: 'Triple Board-Certified' },
+    { icon: ShieldCheck, label: 'FACS Fellow' },
+    { icon: Award, label: 'Fellowship Director' },
+    { icon: Languages, label: 'Hablamos Español' },
+] as const
+
+export type DrKarlinskyHeroProps = {
+    readonly id?: string
+}
+
+export function DrKarlinskyHero({ id = 'hero' }: DrKarlinskyHeroProps) {
+    const surgeon = surgeons[0]
+    if (!surgeon) {
+        return null
+    }
+
+    const firstName = surgeon.name.replace(/^Dr\.\s+/, '').split(' ')[0]
+
+    return (
+        <section
+            id={id}
+            aria-labelledby='dr-karlinsky-hero-heading'
+            className='relative w-full overflow-hidden bg-stone-950 pt-28 pb-16 lg:min-h-[100vh] lg:pt-36 lg:pb-24'
+        >
+            {/* Ambient gradient + gold orbs */}
+            <div className='pointer-events-none absolute inset-0'>
+                <div className='absolute inset-0 bg-[radial-gradient(ellipse_at_top_left,_rgba(212,175,55,0.18),_transparent_60%)]' />
+                <div className='absolute inset-0 bg-[radial-gradient(ellipse_at_bottom_right,_rgba(212,175,55,0.08),_transparent_55%)]' />
+                <div className='bg-gold-500/10 absolute -top-1/4 -left-1/4 h-[600px] w-[600px] rounded-full blur-3xl' />
+                <div className='bg-gold-400/5 absolute right-0 bottom-0 h-[420px] w-[420px] translate-x-1/3 rounded-full blur-3xl' />
+                {/* Hairline grid for tactile depth */}
+                <div className='absolute inset-0 bg-[linear-gradient(to_right,rgba(255,255,255,0.04)_1px,transparent_1px),linear-gradient(to_bottom,rgba(255,255,255,0.04)_1px,transparent_1px)] [mask-image:radial-gradient(ellipse_at_center,black_30%,transparent_70%)] bg-[size:48px_48px]' />
+            </div>
+
+            <div className='relative z-10 mx-auto grid w-full max-w-7xl gap-10 px-6 md:px-10 lg:grid-cols-12 lg:gap-12'>
+                {/* LEFT — Authority + portrait */}
+                <div className='animate-fade-in-up lg:col-span-7'>
+                    {/* Locale + practice line */}
+                    <div className='mb-6 inline-flex flex-wrap items-center gap-3'>
+                        <span className='border-gold-500/30 bg-gold-500/10 inline-flex items-center gap-2 rounded-full border px-3 py-1.5'>
+                            <MapPin className='text-gold-400 h-3.5 w-3.5' />
+                            <span className='text-gold-300 text-xs font-medium tracking-wide uppercase'>
+                                Miami, FL
+                            </span>
+                        </span>
+                        <span className='inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-3 py-1.5 backdrop-blur-sm'>
+                            <span className='bg-gold-400 h-1.5 w-1.5 rounded-full' />
+                            <span className='text-xs font-medium tracking-wide text-stone-300 uppercase'>
+                                Now booking consultations
+                            </span>
+                        </span>
+                    </div>
+
+                    {/* Headline */}
+                    <h1
+                        id='dr-karlinsky-hero-heading'
+                        className='animate-fade-in-up animate-delay-100 mb-5 font-serif text-4xl leading-[1.05] text-white sm:text-5xl lg:text-6xl xl:text-7xl'
+                    >
+                        Meet{' '}
+                        <span className='text-gold-300 italic'>
+                            {surgeon.name}
+                        </span>
+                        <span className='mt-2 block text-2xl font-light text-stone-300 sm:text-3xl lg:text-4xl'>
+                            The Miami surgeon trusted with your most personal
+                            transformation.
+                        </span>
+                    </h1>
+
+                    {/* Subhead / promise */}
+                    <p className='animate-fade-in-up animate-delay-150 mb-8 max-w-xl text-lg leading-relaxed text-stone-300 lg:text-xl'>
+                        Triple board-certified. Fellowship-trained. Known for
+                        results that look unmistakably <em>like you</em> — never
+                        overdone. Book a complimentary consultation with Dr.{' '}
+                        {firstName} and start a plan that actually fits your
+                        body, your life, and your budget.
+                    </p>
+
+                    {/* Portrait + Quote (split inside the left column) */}
+                    <div className='animate-fade-in-up animate-delay-200 mb-8 grid gap-6 sm:grid-cols-5'>
+                        <div className='relative sm:col-span-2'>
+                            <div className='ring-gold-500/20 group relative aspect-[3/4] w-full overflow-hidden rounded-2xl ring-1 sm:rounded-3xl'>
+                                <Image
+                                    src={surgeon.images.featured}
+                                    alt={`${surgeon.name}, ${surgeon.title}`}
+                                    fill
+                                    sizes='(min-width: 1024px) 280px, (min-width: 640px) 38vw, 100vw'
+                                    className='object-cover object-top transition-transform duration-700 group-hover:scale-[1.03]'
+                                    priority
+                                />
+                                <div className='absolute inset-0 bg-gradient-to-t from-stone-950/70 via-transparent to-transparent' />
+                                <div className='absolute right-3 bottom-3 left-3'>
+                                    <div className='border-gold-500/30 inline-flex items-center gap-1.5 rounded-full border bg-stone-950/70 px-2.5 py-1 backdrop-blur-md'>
+                                        <BadgeCheck className='text-gold-400 h-3 w-3' />
+                                        <span className='text-[10px] font-medium tracking-wide text-white uppercase'>
+                                            Medical Director
+                                        </span>
+                                    </div>
+                                </div>
+                            </div>
+                            {/* Decorative gold corner */}
+                            <div className='border-gold-500 absolute -top-2 -left-2 hidden h-10 w-10 rounded-tl-2xl border-t-2 border-l-2 sm:block' />
+                            <div className='border-gold-500 absolute -right-2 -bottom-2 hidden h-10 w-10 rounded-br-2xl border-r-2 border-b-2 sm:block' />
+                        </div>
+
+                        {surgeon.quote && (
+                            <figure className='relative flex flex-col justify-center sm:col-span-3'>
+                                <Quote className='text-gold-500/50 mb-3 h-8 w-8' />
+                                <blockquote className='font-serif text-xl leading-snug text-stone-100 italic md:text-2xl'>
+                                    &ldquo;{surgeon.quote}&rdquo;
+                                </blockquote>
+                                <figcaption className='mt-4 flex items-center gap-3'>
+                                    <span className='from-gold-500 to-gold-300 inline-block h-px w-10 bg-gradient-to-r' />
+                                    <span className='text-gold-400 text-xs font-semibold tracking-[0.2em] uppercase'>
+                                        — Dr. {firstName}
+                                    </span>
+                                </figcaption>
+                            </figure>
+                        )}
+                    </div>
+
+                    {/* Trust pills */}
+                    <ul className='animate-fade-in-up animate-delay-300 flex flex-wrap gap-2.5'>
+                        {TRUST_PILLS.map((pill) => (
+                            <li
+                                key={pill.label}
+                                className='inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-3.5 py-1.5 backdrop-blur-sm transition-colors hover:border-white/20 hover:bg-white/10'
+                            >
+                                <pill.icon className='text-gold-400 h-3.5 w-3.5' />
+                                <span className='text-xs font-medium text-stone-200'>
+                                    {pill.label}
+                                </span>
+                            </li>
+                        ))}
+                    </ul>
+                </div>
+
+                {/* RIGHT — Sticky form */}
+                <div className='animate-fade-in-up animate-delay-200 lg:col-span-5'>
+                    <div className='lg:sticky lg:top-32'>
+                        <div
+                            id={HERO_FORM_ID}
+                            className='ring-gold-500/10 relative rounded-2xl bg-white p-6 shadow-2xl ring-1 shadow-stone-950/40 sm:rounded-3xl md:p-8'
+                        >
+                            {/* Gold tag */}
+                            <div className='from-gold-500 to-gold-400 absolute -top-3 left-6 inline-flex items-center gap-1.5 rounded-full bg-gradient-to-r px-3 py-1 shadow-lg'>
+                                <span className='text-[10px] font-bold tracking-[0.18em] text-stone-950 uppercase'>
+                                    Free · No Obligation
+                                </span>
+                            </div>
+
+                            <ConsultationForm
+                                title={`Book With Dr. ${firstName}`}
+                                subtitle='Complimentary consult • 24-hour response • 100% confidential'
+                                source={CONTACT_SOURCES.DR_KARLINSKY_LANDING}
+                                analyticsFormName='dr_karlinsky_hero_form'
+                                enableAnalytics
+                                redirectOnSuccess='/thank-you'
+                                showPreferredContactTime
+                            />
+                        </div>
+
+                        {/* Below-form micro-trust */}
+                        <p className='mt-4 text-center text-xs text-stone-400'>
+                            Your information is private. We&apos;ll never spam,
+                            sell, or share your data.
+                        </p>
+                    </div>
+                </div>
+            </div>
+        </section>
+    )
+}

--- a/apps/web/components/dr-karlinsky-landing/dr-karlinsky-hero.component.tsx
+++ b/apps/web/components/dr-karlinsky-landing/dr-karlinsky-hero.component.tsx
@@ -46,7 +46,7 @@ export function DrKarlinskyHero({ id = 'hero' }: DrKarlinskyHeroProps) {
         <section
             id={id}
             aria-labelledby='dr-karlinsky-hero-heading'
-            className='relative w-full overflow-hidden bg-stone-950 pt-28 pb-16 lg:min-h-[100vh] lg:pt-36 lg:pb-24'
+            className='relative w-full overflow-hidden bg-stone-950 pt-10 pb-16 sm:pt-14 lg:min-h-[calc(100vh-72px)] lg:pt-20 lg:pb-24'
         >
             {/* Ambient gradient + gold orbs */}
             <div className='pointer-events-none absolute inset-0'>

--- a/apps/web/components/dr-karlinsky-landing/dr-karlinsky-minimal-footer.component.tsx
+++ b/apps/web/components/dr-karlinsky-landing/dr-karlinsky-minimal-footer.component.tsx
@@ -1,0 +1,49 @@
+/**
+ * DrKarlinskyMinimalFooter
+ *
+ * Single-strip legal footer for the ad landing page. Required-only links:
+ *   - Privacy Policy and Terms (legally necessary for FTC + paid-ad platforms)
+ *   - Address + copyright + phone
+ *
+ * Privacy/Terms are the only outbound links — required by Meta and Google ad
+ * policy compliance, and they open in the same tab so abandonment is rare.
+ */
+import Link from 'next/link'
+
+import { siteConfig } from '@/lib/data/site-config'
+
+export function DrKarlinskyMinimalFooter() {
+    const year = new Date().getFullYear()
+
+    return (
+        <footer className='border-t border-stone-200/70 bg-stone-50'>
+            <div className='mx-auto flex w-full max-w-7xl flex-col items-center gap-3 px-6 py-6 text-center text-xs text-stone-500 sm:flex-row sm:justify-between sm:text-left md:px-8'>
+                <p>
+                    © {year} {siteConfig.business.name} ·{' '}
+                    {siteConfig.contact.address}, {siteConfig.contact.city},{' '}
+                    {siteConfig.contact.state} {siteConfig.contact.postalCode}
+                </p>
+                <nav
+                    aria-label='Legal'
+                    className='flex items-center gap-x-4 gap-y-1'
+                >
+                    <Link
+                        href='/privacy'
+                        className='hover:text-gold-700 transition-colors'
+                    >
+                        Privacy
+                    </Link>
+                    <span aria-hidden='true' className='text-stone-300'>
+                        ·
+                    </span>
+                    <Link
+                        href='/terms'
+                        className='hover:text-gold-700 transition-colors'
+                    >
+                        Terms
+                    </Link>
+                </nav>
+            </div>
+        </footer>
+    )
+}

--- a/apps/web/components/dr-karlinsky-landing/dr-karlinsky-minimal-header.component.tsx
+++ b/apps/web/components/dr-karlinsky-landing/dr-karlinsky-minimal-header.component.tsx
@@ -1,0 +1,71 @@
+/**
+ * DrKarlinskyMinimalHeader
+ *
+ * Stripped-down header for the ad landing page. Contains only:
+ *   - Alluring logo (NOT a link to home — keeps visitors on the LP)
+ *   - Phone number (tap-to-call)
+ *   - "Book Consult" CTA scrolling to the hero form
+ *
+ * No nav. No exits. Sticky to the top so the CTA is always one click away.
+ */
+import { Button } from '@workspace/ui/components/button'
+import { Phone } from 'lucide-react'
+import Image from 'next/image'
+
+import { getPhoneLink, siteConfig } from '@/lib/data/site-config'
+
+export type DrKarlinskyMinimalHeaderProps = {
+    readonly formAnchor?: string
+}
+
+export function DrKarlinskyMinimalHeader({
+    formAnchor = '#hero-form',
+}: DrKarlinskyMinimalHeaderProps) {
+    const phoneHref = getPhoneLink()
+
+    return (
+        <header className='sticky top-0 z-40 w-full border-b border-stone-200/60 bg-white/85 backdrop-blur-xl'>
+            <div className='mx-auto flex h-16 w-full max-w-7xl items-center justify-between gap-4 px-4 sm:h-[72px] md:px-8'>
+                {/* Logo (intentionally not linked anywhere) */}
+                <div className='flex items-center'>
+                    <Image
+                        src='/logo.png'
+                        alt='Alluring Plastic Surgery'
+                        width={140}
+                        height={40}
+                        priority
+                        className='h-9 w-auto md:h-10'
+                    />
+                </div>
+
+                {/* Right cluster: phone + book button */}
+                <div className='flex items-center gap-2 sm:gap-4'>
+                    {/* Phone — visible everywhere; collapses to icon on small screens */}
+                    <a
+                        href={phoneHref}
+                        className='hover:bg-gold-50 hover:text-gold-700 inline-flex items-center gap-2 rounded-full px-3 py-2 text-sm font-medium text-stone-700 transition-colors'
+                        aria-label={`Call ${siteConfig.contact.phoneDisplay}`}
+                    >
+                        <Phone className='text-gold-600 h-4 w-4 shrink-0' />
+                        <span className='hidden sm:inline'>
+                            {siteConfig.contact.phoneDisplay}
+                        </span>
+                    </a>
+
+                    <Button
+                        asChild
+                        size='sm'
+                        className='bg-gold-500 hover:bg-gold-600 px-4 text-xs font-bold tracking-wide text-white uppercase shadow-md shadow-amber-500/20 transition-shadow hover:shadow-lg hover:shadow-amber-500/30 sm:px-6 sm:text-sm'
+                    >
+                        <a href={formAnchor}>
+                            <span className='hidden sm:inline'>
+                                Book Consult
+                            </span>
+                            <span className='sm:hidden'>Book</span>
+                        </a>
+                    </Button>
+                </div>
+            </div>
+        </header>
+    )
+}

--- a/apps/web/components/dr-karlinsky-landing/dr-karlinsky-specialties.component.tsx
+++ b/apps/web/components/dr-karlinsky-landing/dr-karlinsky-specialties.component.tsx
@@ -1,0 +1,153 @@
+/**
+ * DrKarlinskySpecialties
+ *
+ * 8-card specialty grid mapped to real procedure pages. Each card invites
+ * deeper research (link to procedure detail) AND offers a fast-path back to
+ * the hero form for visitors ready to book without reading more.
+ */
+import { ArrowUpRight } from 'lucide-react'
+import Link from 'next/link'
+
+import { ContentWrapper } from '@/components/shared/content-wrapper.component'
+import { SectionContainer } from '@/components/shared/section-container.component'
+
+type SpecialtyCard = {
+    readonly title: string
+    readonly procedureSlug: string
+    readonly tagline: string
+}
+
+const SPECIALTIES: readonly SpecialtyCard[] = [
+    {
+        title: 'Brazilian Butt Lift (BBL)',
+        procedureSlug: 'brazilian-butt-lift-bbl-miami',
+        tagline: 'Sculpted curves with safety-first technique.',
+    },
+    {
+        title: 'Mommy Makeover',
+        procedureSlug: 'mommy-makeover-miami',
+        tagline: 'Reclaim your pre-pregnancy silhouette.',
+    },
+    {
+        title: 'Tummy Tuck (Abdominoplasty)',
+        procedureSlug: 'tummy-tuck-miami',
+        tagline: 'A flatter, firmer midsection.',
+    },
+    {
+        title: 'Liposuction & Lipo 360',
+        procedureSlug: 'liposuction-miami',
+        tagline: 'Full-body contouring with precision.',
+    },
+    {
+        title: 'Breast Augmentation & Lift',
+        procedureSlug: 'breast-augmentation-miami',
+        tagline: 'Natural shape, balanced proportions.',
+    },
+    {
+        title: 'Breast Reduction',
+        procedureSlug: 'breast-reduction-miami',
+        tagline: 'Comfort and confidence restored.',
+    },
+    {
+        title: 'Facelift',
+        procedureSlug: 'facelift-miami',
+        tagline: 'Refreshed, rested — never overdone.',
+    },
+    {
+        title: 'Blepharoplasty (Eyelid)',
+        procedureSlug: 'blepharoplasty-miami',
+        tagline: 'Brighter, more open eyes.',
+    },
+] as const
+
+export type DrKarlinskySpecialtiesProps = {
+    readonly id?: string
+    readonly formAnchor?: string
+}
+
+export function DrKarlinskySpecialties({
+    id = 'specialties',
+    formAnchor = '#hero-form',
+}: DrKarlinskySpecialtiesProps) {
+    return (
+        <SectionContainer
+            id={id}
+            variant='default'
+            className='relative overflow-hidden bg-white'
+            paddingY='py-20 lg:py-28'
+        >
+            <ContentWrapper
+                size='xl'
+                paddingX='px-6 md:px-12'
+                className='relative z-10'
+            >
+                <div className='mx-auto mb-14 max-w-3xl text-center lg:mb-16'>
+                    <p className='text-gold-600 mb-3 text-xs font-bold tracking-[0.22em] uppercase'>
+                        Procedures Performed by Dr. Karlinsky
+                    </p>
+                    <h2 className='font-serif text-3xl leading-tight text-stone-900 md:text-4xl lg:text-5xl'>
+                        Eight signature procedures.{' '}
+                        <span className='text-gold-600 italic'>
+                            One uncompromising standard.
+                        </span>
+                    </h2>
+                    <p className='mt-4 text-base leading-relaxed text-stone-600 lg:text-lg'>
+                        Each plan is built around <em>your</em> anatomy and
+                        goals. Not sure which procedure fits? Dr. Karlinsky will
+                        walk you through every option in your free consult.
+                    </p>
+                </div>
+
+                <ul className='grid gap-4 sm:grid-cols-2 lg:grid-cols-4 lg:gap-5'>
+                    {SPECIALTIES.map((specialty, index) => (
+                        <li key={specialty.procedureSlug}>
+                            <Link
+                                href={`/procedures/${specialty.procedureSlug}`}
+                                className='hover:ring-gold-300 group relative flex h-full flex-col justify-between overflow-hidden rounded-xl bg-stone-50 p-5 ring-1 ring-stone-200/70 transition-all duration-300 hover:-translate-y-0.5 hover:bg-white hover:shadow-lg hover:shadow-stone-300/50'
+                            >
+                                {/* Number plate */}
+                                <span
+                                    aria-hidden='true'
+                                    className='text-gold-500/30 group-hover:text-gold-500/60 font-serif text-3xl font-light tabular-nums transition-colors'
+                                >
+                                    {String(index + 1).padStart(2, '0')}
+                                </span>
+
+                                <div className='mt-6'>
+                                    <h3 className='font-serif text-lg leading-snug text-stone-900 md:text-xl'>
+                                        {specialty.title}
+                                    </h3>
+                                    <p className='mt-1.5 text-sm leading-relaxed text-stone-500'>
+                                        {specialty.tagline}
+                                    </p>
+                                </div>
+
+                                <div className='mt-5 flex items-center justify-between border-t border-stone-200/70 pt-4'>
+                                    <span className='text-gold-600 group-hover:text-gold-700 text-xs font-semibold tracking-wide uppercase transition-colors'>
+                                        Explore Procedure
+                                    </span>
+                                    <ArrowUpRight className='text-gold-500 group-hover:text-gold-700 h-4 w-4 transition-all group-hover:translate-x-0.5 group-hover:-translate-y-0.5' />
+                                </div>
+                            </Link>
+                        </li>
+                    ))}
+                </ul>
+
+                {/* Bottom redirect to form */}
+                <div className='mt-12 flex flex-col items-center gap-3 text-center'>
+                    <p className='text-stone-600'>
+                        Considering more than one? Dr. Karlinsky often combines
+                        procedures safely in a single session.
+                    </p>
+                    <Link
+                        href={formAnchor}
+                        className='text-gold-700 hover:text-gold-800 hover:decoration-gold-500 inline-flex items-center gap-2 font-medium underline decoration-stone-300 underline-offset-4 transition-colors'
+                    >
+                        Discuss your combination
+                        <span aria-hidden='true'>↑</span>
+                    </Link>
+                </div>
+            </ContentWrapper>
+        </SectionContainer>
+    )
+}

--- a/apps/web/components/dr-karlinsky-landing/dr-karlinsky-specialties.component.tsx
+++ b/apps/web/components/dr-karlinsky-landing/dr-karlinsky-specialties.component.tsx
@@ -5,7 +5,7 @@
  * deeper research (link to procedure detail) AND offers a fast-path back to
  * the hero form for visitors ready to book without reading more.
  */
-import { ArrowUpRight } from 'lucide-react'
+import { ArrowDownRight } from 'lucide-react'
 import Link from 'next/link'
 
 import { ContentWrapper } from '@/components/shared/content-wrapper.component'
@@ -13,49 +13,40 @@ import { SectionContainer } from '@/components/shared/section-container.componen
 
 type SpecialtyCard = {
     readonly title: string
-    readonly procedureSlug: string
     readonly tagline: string
 }
 
 const SPECIALTIES: readonly SpecialtyCard[] = [
     {
         title: 'Brazilian Butt Lift (BBL)',
-        procedureSlug: 'brazilian-butt-lift-bbl-miami',
         tagline: 'Sculpted curves with safety-first technique.',
     },
     {
         title: 'Mommy Makeover',
-        procedureSlug: 'mommy-makeover-miami',
         tagline: 'Reclaim your pre-pregnancy silhouette.',
     },
     {
         title: 'Tummy Tuck (Abdominoplasty)',
-        procedureSlug: 'tummy-tuck-miami',
         tagline: 'A flatter, firmer midsection.',
     },
     {
         title: 'Liposuction & Lipo 360',
-        procedureSlug: 'liposuction-miami',
         tagline: 'Full-body contouring with precision.',
     },
     {
         title: 'Breast Augmentation & Lift',
-        procedureSlug: 'breast-augmentation-miami',
         tagline: 'Natural shape, balanced proportions.',
     },
     {
         title: 'Breast Reduction',
-        procedureSlug: 'breast-reduction-miami',
         tagline: 'Comfort and confidence restored.',
     },
     {
         title: 'Facelift',
-        procedureSlug: 'facelift-miami',
         tagline: 'Refreshed, rested — never overdone.',
     },
     {
         title: 'Blepharoplasty (Eyelid)',
-        procedureSlug: 'blepharoplasty-miami',
         tagline: 'Brighter, more open eyes.',
     },
 ] as const
@@ -100,9 +91,9 @@ export function DrKarlinskySpecialties({
 
                 <ul className='grid gap-4 sm:grid-cols-2 lg:grid-cols-4 lg:gap-5'>
                     {SPECIALTIES.map((specialty, index) => (
-                        <li key={specialty.procedureSlug}>
+                        <li key={specialty.title}>
                             <Link
-                                href={`/procedures/${specialty.procedureSlug}`}
+                                href={formAnchor}
                                 className='hover:ring-gold-300 group relative flex h-full flex-col justify-between overflow-hidden rounded-xl bg-stone-50 p-5 ring-1 ring-stone-200/70 transition-all duration-300 hover:-translate-y-0.5 hover:bg-white hover:shadow-lg hover:shadow-stone-300/50'
                             >
                                 {/* Number plate */}
@@ -124,9 +115,9 @@ export function DrKarlinskySpecialties({
 
                                 <div className='mt-5 flex items-center justify-between border-t border-stone-200/70 pt-4'>
                                     <span className='text-gold-600 group-hover:text-gold-700 text-xs font-semibold tracking-wide uppercase transition-colors'>
-                                        Explore Procedure
+                                        Ask Dr. Karlinsky
                                     </span>
-                                    <ArrowUpRight className='text-gold-500 group-hover:text-gold-700 h-4 w-4 transition-all group-hover:translate-x-0.5 group-hover:-translate-y-0.5' />
+                                    <ArrowDownRight className='text-gold-500 group-hover:text-gold-700 h-4 w-4 transition-all group-hover:translate-x-0.5 group-hover:translate-y-0.5' />
                                 </div>
                             </Link>
                         </li>

--- a/apps/web/components/dr-karlinsky-landing/dr-karlinsky-trust-strip.component.tsx
+++ b/apps/web/components/dr-karlinsky-landing/dr-karlinsky-trust-strip.component.tsx
@@ -1,0 +1,67 @@
+/**
+ * DrKarlinskyTrustStrip
+ *
+ * Quiet authority bar that anchors credibility right below the hero.
+ * Pulls the certification badges already attached to Dr. Karlinsky's
+ * surgeon record so the SVGs stay the source of truth.
+ */
+import Image from 'next/image'
+
+import { ContentWrapper } from '@/components/shared/content-wrapper.component'
+import { SectionContainer } from '@/components/shared/section-container.component'
+import { surgeons } from '@/lib/data/surgeons/surgeons-data'
+
+export type DrKarlinskyTrustStripProps = {
+    readonly id?: string
+}
+
+export function DrKarlinskyTrustStrip({
+    id = 'trust-strip',
+}: DrKarlinskyTrustStripProps) {
+    const badges = surgeons[0]?.certificationBadges ?? []
+    if (badges.length === 0) {
+        return null
+    }
+
+    return (
+        <SectionContainer
+            id={id}
+            variant='default'
+            className='relative border-y border-stone-200/70 bg-stone-50'
+            paddingY='py-8 lg:py-10'
+        >
+            <ContentWrapper size='xl' paddingX='px-6 md:px-12'>
+                <div className='flex flex-col items-center gap-6 md:flex-row md:items-center md:justify-between md:gap-10'>
+                    <div className='shrink-0 text-center md:text-left'>
+                        <p className='text-gold-600 text-xs font-bold tracking-[0.22em] uppercase'>
+                            Verified Credentials
+                        </p>
+                        <p className='mt-1 font-serif text-lg text-stone-800'>
+                            Trusted by the institutions that matter.
+                        </p>
+                    </div>
+                    <ul
+                        className='-mx-6 flex w-full snap-x items-center gap-5 overflow-x-auto px-6 md:mx-0 md:flex-wrap md:justify-end md:overflow-visible md:px-0'
+                        aria-label='Board certifications and fellowships'
+                    >
+                        {badges.map((badge) => (
+                            <li
+                                key={badge.alt}
+                                className='shrink-0 snap-center rounded-lg bg-white p-2.5 shadow-sm ring-1 ring-stone-200/70 transition-shadow hover:shadow-md'
+                                title={badge.alt}
+                            >
+                                <Image
+                                    src={badge.src}
+                                    alt={badge.alt}
+                                    width={96}
+                                    height={64}
+                                    className='h-12 w-auto object-contain grayscale transition-all duration-300 hover:grayscale-0 md:h-14'
+                                />
+                            </li>
+                        ))}
+                    </ul>
+                </div>
+            </ContentWrapper>
+        </SectionContainer>
+    )
+}

--- a/apps/web/components/dr-karlinsky-landing/dr-karlinsky-why-choose.component.tsx
+++ b/apps/web/components/dr-karlinsky-landing/dr-karlinsky-why-choose.component.tsx
@@ -1,0 +1,127 @@
+/**
+ * DrKarlinskyWhyChoose
+ *
+ * Four reasons-to-choose cards positioned right after the bio. Each card
+ * answers a quiet objection ("is this the right surgeon?") with a concrete
+ * differentiator drawn from her real credentials.
+ */
+import {
+    HeartHandshake,
+    ShieldCheck,
+    Sparkles,
+    Stethoscope,
+} from 'lucide-react'
+import Link from 'next/link'
+
+import { ContentWrapper } from '@/components/shared/content-wrapper.component'
+import { SectionContainer } from '@/components/shared/section-container.component'
+
+const REASONS = [
+    {
+        icon: ShieldCheck,
+        title: 'Triple Board-Certified',
+        body: 'Certified by the American Board of Cosmetic Surgery, American Board of Facial Cosmetic Surgery, and American Board of Surgery — a level of credentialing few cosmetic surgeons hold.',
+        accent: 'Three boards. Zero shortcuts.',
+    },
+    {
+        icon: Stethoscope,
+        title: 'FACS Fellow & Fellowship Director',
+        body: "Fellow of the American College of Surgeons and a Fellowship Director with the American Board of Cosmetic Surgery — meaning she trains other surgeons and meets the field's highest safety standards.",
+        accent: 'Trains the next generation.',
+    },
+    {
+        icon: Sparkles,
+        title: 'Natural, Artistic Results',
+        body: "Dr. Karlinsky tailors every plan to your anatomy, your goals, and your lifestyle. The aim is never “obvious work” — it's a more confident version of you.",
+        accent: 'You, refined. Never overdone.',
+    },
+    {
+        icon: HeartHandshake,
+        title: 'Concierge-Level Care',
+        body: 'From the very first consult through final follow-up, you have a dedicated team. Honest answers, transparent pricing, and a recovery plan that fits your real life.',
+        accent: 'No pressure. Ever.',
+    },
+] as const
+
+export type DrKarlinskyWhyChooseProps = {
+    readonly id?: string
+    readonly formAnchor?: string
+}
+
+export function DrKarlinskyWhyChoose({
+    id = 'why-dr-karlinsky',
+    formAnchor = '#hero-form',
+}: DrKarlinskyWhyChooseProps) {
+    return (
+        <SectionContainer
+            id={id}
+            variant='default'
+            className='relative overflow-hidden bg-stone-50'
+            paddingY='py-20 lg:py-28'
+        >
+            {/* Subtle gold ambient */}
+            <div className='pointer-events-none absolute inset-0'>
+                <div className='bg-gold-200/30 absolute -top-1/4 right-1/4 h-[500px] w-[500px] rounded-full blur-3xl' />
+                <div className='absolute bottom-0 left-0 h-[400px] w-[400px] rounded-full bg-stone-200/40 blur-3xl' />
+            </div>
+
+            <ContentWrapper
+                size='xl'
+                paddingX='px-6 md:px-12'
+                className='relative z-10'
+            >
+                <div className='mx-auto mb-14 max-w-2xl text-center lg:mb-16'>
+                    <p className='text-gold-600 mb-3 text-xs font-bold tracking-[0.22em] uppercase'>
+                        Why Patients Choose Her
+                    </p>
+                    <h2 className='font-serif text-3xl leading-tight text-stone-900 md:text-4xl lg:text-5xl'>
+                        Four reasons women fly into Miami{' '}
+                        <span className='text-gold-600 italic'>
+                            specifically for Dr. Karlinsky.
+                        </span>
+                    </h2>
+                </div>
+
+                <div className='grid gap-5 md:grid-cols-2 lg:gap-6'>
+                    {REASONS.map((reason) => (
+                        <article
+                            key={reason.title}
+                            className='hover:ring-gold-300/60 group relative overflow-hidden rounded-2xl bg-white p-7 shadow-sm ring-1 ring-stone-200/70 transition-all duration-300 hover:-translate-y-0.5 hover:shadow-xl hover:shadow-stone-300/40 md:p-9'
+                        >
+                            {/* Hover gold gradient */}
+                            <div className='from-gold-50/0 to-gold-50/0 group-hover:from-gold-50/0 group-hover:to-gold-100/40 pointer-events-none absolute inset-0 bg-gradient-to-br opacity-0 transition-opacity duration-500 group-hover:opacity-100' />
+
+                            <div className='relative'>
+                                <div className='mb-5 flex items-start justify-between gap-4'>
+                                    <span className='from-gold-500 to-gold-400 group-hover:shadow-gold-500/30 inline-flex h-12 w-12 items-center justify-center rounded-xl bg-gradient-to-br shadow-md transition-shadow duration-300 group-hover:shadow-lg'>
+                                        <reason.icon className='h-6 w-6 text-stone-950' />
+                                    </span>
+                                    <span className='text-gold-600 text-[10px] font-semibold tracking-[0.18em] uppercase'>
+                                        {reason.accent}
+                                    </span>
+                                </div>
+                                <h3 className='mb-3 font-serif text-xl text-stone-900 md:text-2xl'>
+                                    {reason.title}
+                                </h3>
+                                <p className='text-base leading-relaxed text-stone-600'>
+                                    {reason.body}
+                                </p>
+                            </div>
+                        </article>
+                    ))}
+                </div>
+
+                {/* Bottom anchor CTA */}
+                <div className='mt-12 text-center'>
+                    <Link
+                        href={formAnchor}
+                        className='text-gold-700 hover:text-gold-800 hover:decoration-gold-500 inline-flex items-center gap-2 font-medium underline decoration-stone-300 underline-offset-4 transition-colors'
+                    >
+                        Ready to talk it through? Book your consult
+                        <span aria-hidden='true'>↑</span>
+                    </Link>
+                </div>
+            </ContentWrapper>
+        </SectionContainer>
+    )
+}

--- a/apps/web/components/landing/mini-lead-capture.component.tsx
+++ b/apps/web/components/landing/mini-lead-capture.component.tsx
@@ -27,15 +27,22 @@ import { ContentWrapper } from '@/components/shared/content-wrapper.component'
 import { useContactFormSubmission } from '@/hooks/useContactFormSubmission.hook'
 import {
     CONTACT_SOURCES,
+    type ContactSource,
     type LeadCaptureInput,
     leadCaptureSchema,
 } from '@/lib/types/forms/contact-form.type'
 
 export type MiniLeadCaptureProps = {
     readonly id?: string
+    readonly source?: ContactSource
+    readonly analyticsFormName?: string
 }
 
-export function MiniLeadCapture({ id = 'mini-capture' }: MiniLeadCaptureProps) {
+export function MiniLeadCapture({
+    id = 'mini-capture',
+    source = CONTACT_SOURCES.LANDING_PAGE,
+    analyticsFormName = 'landing_mini_capture',
+}: MiniLeadCaptureProps) {
     const form = useForm<LeadCaptureInput>({
         resolver: zodResolver(leadCaptureSchema),
         defaultValues: {
@@ -47,9 +54,9 @@ export function MiniLeadCapture({ id = 'mini-capture' }: MiniLeadCaptureProps) {
 
     const { submit, state, isSubmitting, isSuccess, isError } =
         useContactFormSubmission({
-            source: CONTACT_SOURCES.LANDING_PAGE,
+            source,
             enableAnalytics: true,
-            analyticsFormName: 'landing_mini_capture',
+            analyticsFormName,
             redirectOnSuccess: '/thank-you',
             onSuccess: () => {
                 form.reset()

--- a/apps/web/components/layout/conditional-layout.component.tsx
+++ b/apps/web/components/layout/conditional-layout.component.tsx
@@ -8,9 +8,10 @@ import { Header } from './header.component'
 
 /**
  * Routes that should not have header/footer
- * These are standalone pages like link-in-bio
+ * These are standalone pages like link-in-bio and ad landing pages
+ * that ship with their own minimal chrome.
  */
-const STANDALONE_ROUTES = ['/links']
+const STANDALONE_ROUTES = ['/links', '/dr-victoria-karlinsky']
 
 interface ConditionalLayoutProps {
     children: ReactNode

--- a/apps/web/components/layout/conditional-layout.component.tsx
+++ b/apps/web/components/layout/conditional-layout.component.tsx
@@ -8,10 +8,10 @@ import { Header } from './header.component'
 
 /**
  * Routes that should not have header/footer
- * These are standalone pages like link-in-bio and ad landing pages
- * that ship with their own minimal chrome.
+ * These are standalone pages like link-in-bio (/links) and paid ad landing
+ * pages under /landing/*, which ship with their own minimal chrome.
  */
-const STANDALONE_ROUTES = ['/links', '/dr-victoria-karlinsky']
+const STANDALONE_ROUTES = ['/links', '/landing']
 
 interface ConditionalLayoutProps {
     children: ReactNode

--- a/apps/web/lib/data/faq/dr-karlinsky-faq.data.ts
+++ b/apps/web/lib/data/faq/dr-karlinsky-faq.data.ts
@@ -1,0 +1,100 @@
+/**
+ * Dr. Victoria Karlinsky Landing Page FAQ Data
+ *
+ * Categorized FAQ items tailored to the doctor-specific landing page.
+ * Categories address the four objection clusters most common when
+ * choosing a surgeon: who she is, the consult itself, safety/results,
+ * and cost/financing.
+ */
+import { siteConfig } from '@/lib/data/site-config'
+import type { FaqCategory, FaqItem } from '@/lib/types/shared/faq.type'
+
+export const drKarlinskyFaqCategories: FaqCategory[] = [
+    { id: 'about', label: 'About Dr. Karlinsky' },
+    { id: 'consultation', label: 'Your Consultation' },
+    { id: 'safety', label: 'Safety & Results' },
+    { id: 'cost', label: 'Cost & Financing' },
+]
+
+export const drKarlinskyFaqData: Record<string, FaqItem[]> = {
+    about: [
+        {
+            question: 'Is Dr. Karlinsky board certified?',
+            answer: `Yes — and not by one board, but three. Dr. Victoria Karlinsky is certified by the American Board of Cosmetic Surgery, the American Board of Facial Cosmetic Surgery, and the American Board of Surgery. She is also a Fellow of the American College of Surgeons (FACS), a Fellow of the American Academy of Cosmetic Surgery, and a Fellowship Director with the American Board of Cosmetic Surgery.`,
+        },
+        {
+            question: 'How experienced is she?',
+            answer: `Dr. Karlinsky has performed thousands of cosmetic and reconstructive procedures throughout her career. She trained at Beth Israel Medical Center in NYC and completed a fellowship at the Facial Plastic & Cosmetic Surgical Center in Texas. As a Fellowship Director, she now trains other surgeons in advanced cosmetic surgery techniques.`,
+        },
+        {
+            question: 'What is her surgical philosophy?',
+            answer: `Three pillars: safety first, personalization always, and natural results. She rejects the "one-size-fits-all" approach — every plan is built around your anatomy, your goals, and your lifestyle. The aim is never "obvious work" — it's a more confident version of you.`,
+        },
+        {
+            question: 'Where can I verify her credentials?',
+            answer: `Every credential listed on this page is independently verifiable. You can find Dr. Karlinsky's verified profiles on Healthgrades and RealSelf — both linked in the credentials section above. Board certifications can also be looked up directly on each board's website.`,
+        },
+    ],
+    consultation: [
+        {
+            question: 'What happens during the consultation?',
+            answer: `You'll meet privately with Dr. Karlinsky to discuss your goals. She'll evaluate your anatomy, walk you through suitable options, show you before-and-after results from similar cases, and provide a detailed all-inclusive quote. There's no pressure to make a decision — many patients book a consult months before deciding.`,
+        },
+        {
+            question: 'Is the consultation really free?',
+            answer: `Yes, completely complimentary with no obligation. We don't charge for an initial consultation because we want you to feel fully informed before committing to anything.`,
+        },
+        {
+            question: 'Can I do a virtual consultation first?',
+            answer: `Absolutely. Many out-of-state and international patients start with a virtual consult. You can discuss your goals, see preliminary recommendations, and get a quote estimate before flying to Miami.`,
+        },
+        {
+            question: 'How soon can I book?',
+            answer: `Consultation appointments are typically available within 1–2 weeks. Call us at ${siteConfig.contact.phoneDisplay} or fill out the form above and our patient concierge will work around your schedule.`,
+        },
+    ],
+    safety: [
+        {
+            question: 'Is plastic surgery actually safe?',
+            answer: `When performed by a triple board-certified surgeon in an accredited facility, the risk profile is excellent. Dr. Karlinsky's safety standards meet — and often exceed — what's required by the boards she sits on. Hospital-grade protocols, advanced monitoring, and a dedicated anesthesiology team accompany every procedure.`,
+        },
+        {
+            question: 'Will I look natural — or "done"?',
+            answer: `Natural is the entire point. Dr. Karlinsky tailors each procedure to your existing proportions and features. The goal is always "you, refreshed" — never the obvious cookie-cutter look. Bring inspiration photos to your consultation; she'll be candid about what's achievable for your anatomy.`,
+        },
+        {
+            question: 'Can she combine multiple procedures safely?',
+            answer: `Often, yes. Many patients save recovery time by combining a Mommy Makeover (tummy tuck + breast surgery + lipo) into one session. Whether combination is safe for you depends on your health, the specific procedures, and total surgical time. Dr. Karlinsky will give you a candid recommendation in your consult.`,
+        },
+        {
+            question: 'How long is recovery?',
+            answer: `Recovery varies by procedure. Most patients return to desk work in 1–2 weeks and resume full activities in 4–6 weeks. Dr. Karlinsky will give you a procedure-specific recovery timeline at your consultation, plus a 24/7 concierge contact for the entire post-op period.`,
+        },
+    ],
+    cost: [
+        {
+            question: 'How much does Dr. Karlinsky cost?',
+            answer: `Pricing depends on the procedure(s), surgical complexity, and recovery support you need. Quotes are all-inclusive — surgeon's fees, anesthesia, facility, and standard follow-up — with no hidden add-ons. You'll receive your personalized quote at the end of your consult.`,
+        },
+        {
+            question: 'What financing do you accept?',
+            answer: `We partner with Cherry, CareCredit, and United Credit. Many patients qualify for 0% APR for 12–24 months, and weekly payments often start as low as $27/week depending on the procedure and approved term. You can apply for pre-approval before your consult so you know your budget walking in.`,
+        },
+        {
+            question: 'Are there any hidden fees?',
+            answer: `Never. The quote you receive includes the surgeon's fee, anesthesia, facility costs, and your standard post-op follow-up. We believe in complete transparency — what we quote is what you pay.`,
+        },
+        {
+            question: 'Is the deposit refundable?',
+            answer: `If your surgery is cancelled by us for medical reasons, your deposit is fully refunded. Patient-initiated cancellations and reschedules are handled case-by-case — we'll walk you through the policy clearly before you put anything down.`,
+        },
+    ],
+}
+
+export const drKarlinskyFaqConfig = {
+    badge: 'Honest Answers',
+    title: 'Questions Patients Ask About',
+    subtitle: 'Dr. Karlinsky.',
+    description:
+        "If you're researching surgeons (and you should be), here are the questions we hear most. Don't see yours? Bring it to your consult.",
+}

--- a/apps/web/lib/types/forms/contact-form.type.ts
+++ b/apps/web/lib/types/forms/contact-form.type.ts
@@ -33,6 +33,7 @@ export const CONTACT_SOURCES = {
     LANDING_PAGE: 'landing-page',
     PROCEDURE_PAGE: 'procedure-page',
     QUIZ: 'quiz',
+    DR_KARLINSKY_LANDING: 'dr-karlinsky-landing',
 } as const
 
 export type ContactSource =


### PR DESCRIPTION
## Summary

- New dedicated ad-LP at `/dr-victoria-karlinsky`, separate from the existing `/dr-karlinsky` bio page so paid traffic and organic discovery stay attribution-clean
- World-class luxury design: custom hero (split layout with sticky `ConsultationForm`), trust strip, magazine-style about, 4 differentiator cards, 8-specialty grid, mid-page mini capture, gallery, reviews, full credentials wall (E-E-A-T), financing, categorized FAQ, final luxury CTA
- Page is **fully sealed** for ad traffic: stripped sticky header (logo + phone + Book CTA), legal-only footer, specialty cards scroll to the form (not procedure pages), Google review out-links disabled — only allowed exits are `tel:`, in-page anchors, Privacy/Terms (legal compliance), and Healthgrades/RealSelf (E-E-A-T credential verification)

## Implementation notes

- New `DR_KARLINSKY_LANDING` contact source for clean lead segmentation in the contact-submission DB
- `MiniLeadCapture` extended with optional `source` / `analyticsFormName` props (defaults preserve existing usage)
- `/dr-victoria-karlinsky` added to `STANDALONE_ROUTES` so the global `Header` / `Footer` are skipped; the page provides its own minimal versions
- Schemas emitted: `WebPage`, `FAQPage`, `Service`, `Physician` (full E-E-A-T with credentials, alumniOf, knowsAbout, sameAs to Healthgrades + RealSelf)
- All sections SSR — only the `ConsultationForm` is a client component (form lifecycle requires it)
- Reuses `siteConfig` for phone/address; reuses surgeon record from `surgeons-data.ts`; no hardcoded business info

## Test plan

- [ ] Visit `/dr-victoria-karlinsky` and confirm minimal header (logo + phone + Book button) and minimal footer (copyright/address + Privacy/Terms only) — no main-site nav
- [ ] Click each of the 8 specialty cards — confirm each scrolls to `#hero-form` and does NOT navigate to a `/procedures/...` page
- [ ] Submit the hero form with test data — confirm redirect to `/thank-you` and a row appears in `contactSubmission` with `source = 'dr-karlinsky-landing'`
- [ ] Submit the mid-page mini capture — confirm same redirect and `source = 'dr-karlinsky-landing'`
- [ ] Confirm exit-intent popup does NOT appear after a successful form submission (sessionStorage flag)
- [ ] Mobile (390px) hero stacks copy → portrait → form correctly; sticky header stays usable
- [ ] Run page through Google Rich Results test → confirm `Physician`, `WebPage`, `FAQPage`, `Service` schemas pass
- [ ] Run Lighthouse mobile — Performance > 90, SEO > 95, Accessibility > 95
- [ ] Verify the existing `/dr-karlinsky` bio page is unchanged and still renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)