### PR TITLE
fix(redirects): point /dr-karlinsky-ig to the new doctor landing page

### DIFF
--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -78,7 +78,7 @@ const nextConfig = {
             {
                 source: '/dr-karlinsky-ig',
                 destination:
-                    '/miami-plastic-surgery-specials?utm_source=doctor&utm_medium=dr-karlinsky',
+                    '/landing/dr-victoria-karlinsky?utm_source=doctor&utm_medium=dr-karlinsky',
                 permanent: true,
             },
             {


### PR DESCRIPTION
## Summary

- Update the `/dr-karlinsky-ig` redirect (Dr. Karlinsky's IG bio shortlink) to land on `/landing/dr-victoria-karlinsky` instead of the generic `/miami-plastic-surgery-specials`
- UTM params (`utm_source=doctor&utm_medium=dr-karlinsky`) are preserved so attribution in the contact-submission DB stays consistent
- Doctor-source traffic now arrives on the page where the form, schemas, and stripped chrome are tuned for that visitor's intent — no nav distractions, hero CTA front and center

## Test plan

- [ ] Visit `https://www.alluringplasticsurgery.com/dr-karlinsky-ig` after deploy and confirm a 308 redirect to `/landing/dr-victoria-karlinsky?utm_source=doctor&utm_medium=dr-karlinsky`
- [ ] Submit a test lead from the redirected page and confirm the row in `contactSubmission` shows `utmSource=doctor` and `utmMedium=dr-karlinsky`
- [ ] Note: `next.config.mjs` redirects only take effect after a server restart / redeploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated routing configuration for the doctor profile link to direct users to the new landing page destination with updated tracking parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->