### PR TITLE
feat(landing): re-tune Dr. Karlinsky LP for IG-bio-link traffic

### DIFF
--- a/apps/web/app/landing/dr-victoria-karlinsky/page.tsx
+++ b/apps/web/app/landing/dr-victoria-karlinsky/page.tsx
@@ -1,15 +1,17 @@
 /**
  * Dr. Victoria Karlinsky — Lead Conversion Landing Page
  *
- * Dedicated landing page for paid ad traffic targeting Dr. Karlinsky's name
- * and high-intent organic searches. Conversion-optimized: every section drives
- * toward the hero ConsultationForm (#hero-form).
+ * Optimized for warm Instagram-bio-link traffic. The visitor already
+ * follows Dr. Karlinsky on IG, so the page leads with results and gives
+ * them one decisive booking path — not a credentials wall.
  *
  * URL: /landing/dr-victoria-karlinsky
  * Lives under /landing/* so the global header/footer are auto-stripped via
- * STANDALONE_ROUTES, and so future ad LPs share the same namespace and chrome
- * treatment. Distinct from /dr-karlinsky (the canonical bio page) so paid
- * traffic and organic discovery stay separate.
+ * STANDALONE_ROUTES, and so future ad LPs share the same namespace and
+ * chrome treatment. Distinct from /dr-karlinsky (the canonical bio page)
+ * so paid traffic and organic discovery stay separate.
+ *
+ * Entry point for IG: `/dr-karlinsky-ig` (308 redirect appends UTMs).
  */
 import {
     FAQSchema,
@@ -19,15 +21,11 @@ import {
 } from '@workspace/seo/react'
 
 import { ContainerLayout } from '@/components/container-layout.component'
-import { DrKarlinskyAbout } from '@/components/dr-karlinsky-landing/dr-karlinsky-about.component'
-import { DrKarlinskyCredentialsWall } from '@/components/dr-karlinsky-landing/dr-karlinsky-credentials-wall.component'
 import { DrKarlinskyHero } from '@/components/dr-karlinsky-landing/dr-karlinsky-hero.component'
 import { DrKarlinskyMinimalFooter } from '@/components/dr-karlinsky-landing/dr-karlinsky-minimal-footer.component'
 import { DrKarlinskyMinimalHeader } from '@/components/dr-karlinsky-landing/dr-karlinsky-minimal-header.component'
 import { DrKarlinskySpecialties } from '@/components/dr-karlinsky-landing/dr-karlinsky-specialties.component'
-import { DrKarlinskyTrustStrip } from '@/components/dr-karlinsky-landing/dr-karlinsky-trust-strip.component'
-import { DrKarlinskyWhyChoose } from '@/components/dr-karlinsky-landing/dr-karlinsky-why-choose.component'
-import { MiniLeadCapture } from '@/components/landing/mini-lead-capture.component'
+import { DrKarlinskyStickyMobileCTA } from '@/components/dr-karlinsky-landing/dr-karlinsky-sticky-mobile-cta.component'
 import { CTASection } from '@/components/shared/cta-section.component'
 import { CategorizedFAQ } from '@/components/shared/faq-categorized.component'
 import { GalleryCarousel } from '@/components/shared/gallery-carousel.component'
@@ -43,7 +41,6 @@ import { surgeons } from '@/lib/data/surgeons/surgeons-data'
 import { getSpecialsFeaturedGalleryImages } from '@/lib/queries/gallery/specials-gallery.query'
 import { seoConfig } from '@/lib/seo-config'
 import { toNextMetadata } from '@/lib/seo/metadata'
-import { CONTACT_SOURCES } from '@/lib/types/forms/contact-form.type'
 
 const HERO_FORM_ANCHOR = '#hero-form'
 const PAGE_PATH = '/landing/dr-victoria-karlinsky'
@@ -51,14 +48,14 @@ const PAGE_URL = `${seoConfig.siteUrl}${PAGE_PATH}`
 
 export const metadata = toNextMetadata(seoConfig, {
     canonical: PAGE_PATH,
-    title: 'Dr. Victoria Karlinsky | Triple Board-Certified Miami Surgeon',
+    title: 'Book With Dr. Karlinsky · Triple Board-Certified Miami Surgeon',
     description:
-        'Meet Dr. Victoria Karlinsky — triple board-certified cosmetic surgeon and FACS Fellow in Miami. BBL, mommy makeover, tummy tuck, breast & facial surgery. Free consult. Financing from $27/week.',
+        "Free consult with Dr. Victoria Karlinsky — triple board-certified Miami cosmetic surgeon. BBL, mommy makeover, tummy tuck, breast & facial surgery. Financing from $27/week. We'll text you within 24 hours.",
 
     openGraph: {
-        title: 'Dr. Victoria Karlinsky | Triple Board-Certified Miami Surgeon',
+        title: 'Book With Dr. Karlinsky · Triple Board-Certified Miami Surgeon',
         description:
-            'Meet Dr. Victoria Karlinsky — triple board-certified cosmetic surgeon in Miami. Triple board-certified, FACS Fellow, fellowship director. Book your free consultation.',
+            "Free consult with Dr. Victoria Karlinsky in Miami. Triple board-certified. Financing available. We'll text you within 24 hours.",
         url: PAGE_URL,
         type: 'profile',
         siteName: seoConfig.siteName,
@@ -74,9 +71,9 @@ export const metadata = toNextMetadata(seoConfig, {
 
     twitter: {
         card: 'summary_large_image',
-        title: 'Dr. Victoria Karlinsky | Miami Cosmetic Surgeon',
+        title: 'Book With Dr. Karlinsky · Miami Cosmetic Surgeon',
         description:
-            'Triple board-certified. FACS Fellow. Now booking complimentary consultations in Miami.',
+            'Triple board-certified. Free consult. Booking this month — virtual or in-person.',
         images: [`${seoConfig.siteUrl}/og-image.jpg`],
     },
 
@@ -106,15 +103,13 @@ export default async function DrVictoriaKarlinskyLandingPage() {
           ]
         : []
 
-    const phoneTel = siteConfig.contact.phone.replace(/\D/g, '')
-
     return (
         <>
             {/* Page schema */}
             <WebPageSchema
                 name={`Dr. Victoria Karlinsky - ${siteConfig.business.name}`}
                 url={PAGE_URL}
-                description='Meet Dr. Victoria Karlinsky, triple board-certified cosmetic surgeon at Alluring Plastic Surgery Miami. Book a complimentary consultation.'
+                description='Book a complimentary consultation with Dr. Victoria Karlinsky, triple board-certified cosmetic surgeon at Alluring Plastic Surgery Miami.'
             />
 
             <FAQSchema items={faqSchemaItems} />
@@ -186,47 +181,26 @@ export default async function DrVictoriaKarlinskyLandingPage() {
             {/* Stripped chrome — no nav exits, just logo + phone + book CTA */}
             <DrKarlinskyMinimalHeader formAnchor={HERO_FORM_ANCHOR} />
 
-            {/* Page content */}
+            {/* Page content — IG-warm flow: hero → results → voices →
+                procedures → answers → financing → final CTA */}
             <ContainerLayout as='main' noPaddingTop noPadding size='full'>
                 <DrKarlinskyHero id='hero' />
-
-                <DrKarlinskyTrustStrip id='trust-strip' />
-
-                <DrKarlinskyAbout
-                    id='about-doctor'
-                    formAnchor={HERO_FORM_ANCHOR}
-                />
-
-                <DrKarlinskyWhyChoose
-                    id='why-dr-karlinsky'
-                    formAnchor={HERO_FORM_ANCHOR}
-                />
-
-                <DrKarlinskySpecialties
-                    id='specialties'
-                    formAnchor={HERO_FORM_ANCHOR}
-                />
-
-                <MiniLeadCapture
-                    id='mini-capture'
-                    source={CONTACT_SOURCES.DR_KARLINSKY_LANDING}
-                    analyticsFormName='dr_karlinsky_mini_capture'
-                />
 
                 <GalleryCarousel id='gallery' images={galleryImages} />
 
                 <GoogleReviews
                     title='Patients on Dr. Karlinsky'
-                    subtitle='Verified Google reviews from real patients'
+                    subtitle='Verified Google reviews'
                     limit={3}
                     showGoogleLink={false}
                     showViewAllButton={false}
                     includeSchema={false}
                 />
 
-                <DrKarlinskyCredentialsWall id='credentials' />
-
-                <WeeklyPayments id='financing' formAnchor={HERO_FORM_ANCHOR} />
+                <DrKarlinskySpecialties
+                    id='specialties'
+                    formAnchor={HERO_FORM_ANCHOR}
+                />
 
                 <CategorizedFAQ
                     id='faq'
@@ -239,34 +213,31 @@ export default async function DrVictoriaKarlinskyLandingPage() {
                     variant='default'
                     showBackgroundDecoration={true}
                     includeSchema={false}
-                    ctaConfig={{
-                        title: 'Still have questions?',
-                        description:
-                            'Our patient concierge is happy to talk it through — no pressure, just honest answers.',
-                        buttonText: 'Call Now',
-                        phoneNumber: phoneTel,
-                    }}
                 />
+
+                <WeeklyPayments id='financing' formAnchor={HERO_FORM_ANCHOR} />
 
                 <CTASection
                     id='final-cta'
                     variant='luxury'
                     eyebrow='Take the First Step'
-                    heading='Ready to meet Dr. Karlinsky?'
-                    description='Triple board-certified. FACS Fellow. Fellowship Director. Now booking complimentary consultations in Miami — virtual or in-person.'
+                    heading="Let's plan yours."
+                    description='Free consult. Honest plan. No pressure — just answers, when you’re ready.'
                     primaryButton={{
                         text: 'Book My Free Consultation',
                         href: HERO_FORM_ANCHOR,
-                    }}
-                    secondaryButton={{
-                        text: `Call ${siteConfig.contact.phoneDisplay}`,
-                        href: `tel:${phoneTel}`,
                     }}
                     size='lg'
                 />
             </ContainerLayout>
 
             <DrKarlinskyMinimalFooter />
+
+            {/* Mobile-only sticky booking bar — hides while hero form is on screen */}
+            <DrKarlinskyStickyMobileCTA
+                formAnchor={HERO_FORM_ANCHOR}
+                heroFormId='hero-form'
+            />
         </>
     )
 }

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -12,6 +12,7 @@ import { FloatingChatButton } from '@/components/chat/floating-chat-button.compo
 import { FloatingFeedbackButton } from '@/components/feedback/floating-feedback-button.component'
 import { ExitIntentPopup } from '@/components/home/exit-intent-popup.component'
 import { ConditionalLayout } from '@/components/layout/conditional-layout.component'
+import { NonStandaloneOnly } from '@/components/layout/non-standalone-only.component'
 import { AnnouncementBar } from '@/components/promotions/announcement-bar.component'
 import { PromoModalWrapper } from '@/components/promotions/promo-modal-wrapper.component'
 import { Providers } from '@/components/providers'
@@ -157,13 +158,17 @@ export default function RootLayout({
                     <ExitIntentPopup />
                     {/* Promotion Modal - Timed popup with lead capture */}
                     <PromoModalWrapper />
-                    {/* Mobile Call Button - visible on mobile devices only */}
+                    {/* Mobile Call Button - visible on mobile devices only.
+                        Suppressed on standalone routes (/landing, /links) so
+                        ad/IG landing pages can ship their own chrome. */}
                     {isMobileCallButtonEnabled && (
-                        <MobileCallButton
-                            position='bottom-left'
-                            style='icon-only'
-                            isBanner={false}
-                        />
+                        <NonStandaloneOnly>
+                            <MobileCallButton
+                                position='bottom-left'
+                                style='icon-only'
+                                isBanner={false}
+                            />
+                        </NonStandaloneOnly>
                     )}
                     {/* Beta Feedback Button - visible during beta testing */}
                     {isBetaMode && <FloatingFeedbackButton />}

--- a/apps/web/components/dr-karlinsky-landing/dr-karlinsky-hero.component.tsx
+++ b/apps/web/components/dr-karlinsky-landing/dr-karlinsky-hero.component.tsx
@@ -1,18 +1,20 @@
 /**
  * DrKarlinskyHero
  *
- * Lead-conversion hero for Dr. Victoria Karlinsky's landing page.
+ * Lead-conversion hero for warm Instagram-bio-link traffic. The visitor
+ * already follows Dr. Karlinsky on IG — we don't introduce her, we
+ * acknowledge her work and pivot to "let's plan yours."
  *
- * Layout: portrait + authority on the left, ConsultationForm on the right.
- * Mobile stacks form-first (above the fold) with portrait moving below the
- * headline so the call-to-action stays one tap away.
+ * Layout: portrait + authority on the left, compact ConsultationForm on
+ * the right (3 fields + consent). Mobile stacks form-first so the call
+ * to action stays one tap away.
  */
 import {
     Award,
     BadgeCheck,
+    ExternalLink,
     Languages,
     MapPin,
-    Quote,
     ShieldCheck,
 } from 'lucide-react'
 import Image from 'next/image'
@@ -41,6 +43,8 @@ export function DrKarlinskyHero({ id = 'hero' }: DrKarlinskyHeroProps) {
     }
 
     const firstName = surgeon.name.replace(/^Dr\.\s+/, '').split(' ')[0]
+    const healthgradesUrl = surgeon.externalProfiles?.healthgrades
+    const realselfUrl = surgeon.externalProfiles?.realself
 
     return (
         <section
@@ -72,80 +76,55 @@ export function DrKarlinskyHero({ id = 'hero' }: DrKarlinskyHeroProps) {
                         <span className='inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-3 py-1.5 backdrop-blur-sm'>
                             <span className='bg-gold-400 h-1.5 w-1.5 rounded-full' />
                             <span className='text-xs font-medium tracking-wide text-stone-300 uppercase'>
-                                Now booking consultations
+                                Booking this month
                             </span>
                         </span>
                     </div>
 
-                    {/* Headline */}
+                    {/* Headline — IG-warm voice */}
                     <h1
                         id='dr-karlinsky-hero-heading'
                         className='animate-fade-in-up animate-delay-100 mb-5 font-serif text-4xl leading-[1.05] text-white sm:text-5xl lg:text-6xl xl:text-7xl'
                     >
-                        Meet{' '}
-                        <span className='text-gold-300 italic'>
-                            {surgeon.name}
-                        </span>
-                        <span className='mt-2 block text-2xl font-light text-stone-300 sm:text-3xl lg:text-4xl'>
-                            The Miami surgeon trusted with your most personal
-                            transformation.
+                        You followed{' '}
+                        <span className='text-gold-300 italic'>her work.</span>
+                        <span className='mt-2 block text-3xl font-light text-stone-200 sm:text-4xl lg:text-5xl'>
+                            Now let&apos;s plan yours.
                         </span>
                     </h1>
 
-                    {/* Subhead / promise */}
+                    {/* Subhead / promise — tight, benefit-led */}
                     <p className='animate-fade-in-up animate-delay-150 mb-8 max-w-xl text-lg leading-relaxed text-stone-300 lg:text-xl'>
-                        Triple board-certified. Fellowship-trained. Known for
-                        results that look unmistakably <em>like you</em> — never
-                        overdone. Book a complimentary consultation with Dr.{' '}
-                        {firstName} and start a plan that actually fits your
-                        body, your life, and your budget.
+                        Triple board-certified Miami surgeon. Booking
+                        complimentary consults this month — virtual or
+                        in-person. Honest plan. No pressure.
                     </p>
 
-                    {/* Portrait + Quote (split inside the left column) */}
-                    <div className='animate-fade-in-up animate-delay-200 mb-8 grid gap-6 sm:grid-cols-5'>
-                        <div className='relative sm:col-span-2'>
-                            <div className='ring-gold-500/20 group relative aspect-[3/4] w-full overflow-hidden rounded-2xl ring-1 sm:rounded-3xl'>
-                                <Image
-                                    src={surgeon.images.featured}
-                                    alt={`${surgeon.name}, ${surgeon.title}`}
-                                    fill
-                                    sizes='(min-width: 1024px) 280px, (min-width: 640px) 38vw, 100vw'
-                                    className='object-cover object-top transition-transform duration-700 group-hover:scale-[1.03]'
-                                    priority
-                                />
-                                <div className='absolute inset-0 bg-gradient-to-t from-stone-950/70 via-transparent to-transparent' />
-                                <div className='absolute right-3 bottom-3 left-3'>
-                                    <div className='border-gold-500/30 inline-flex items-center gap-1.5 rounded-full border bg-stone-950/70 px-2.5 py-1 backdrop-blur-md'>
-                                        <BadgeCheck className='text-gold-400 h-3 w-3' />
-                                        <span className='text-[10px] font-medium tracking-wide text-white uppercase'>
-                                            Medical Director
-                                        </span>
-                                    </div>
+                    {/* Portrait — slimmer footprint, mobile-friendly */}
+                    <div className='animate-fade-in-up animate-delay-200 mb-8 max-w-sm'>
+                        <div className='ring-gold-500/20 group relative aspect-[4/5] w-full overflow-hidden rounded-2xl ring-1 sm:rounded-3xl'>
+                            <Image
+                                src={surgeon.images.featured}
+                                alt={`${surgeon.name}, ${surgeon.title}`}
+                                fill
+                                sizes='(min-width: 1024px) 380px, (min-width: 640px) 50vw, 100vw'
+                                className='object-cover object-top transition-transform duration-700 group-hover:scale-[1.03]'
+                                priority
+                            />
+                            <div className='absolute inset-0 bg-gradient-to-t from-stone-950/80 via-transparent to-transparent' />
+                            <div className='absolute right-3 bottom-3 left-3 flex items-end justify-between gap-2'>
+                                <div className='border-gold-500/30 inline-flex items-center gap-1.5 rounded-full border bg-stone-950/70 px-2.5 py-1 backdrop-blur-md'>
+                                    <BadgeCheck className='text-gold-400 h-3 w-3' />
+                                    <span className='text-[10px] font-medium tracking-wide text-white uppercase'>
+                                        Dr. {firstName} · Medical Director
+                                    </span>
                                 </div>
                             </div>
-                            {/* Decorative gold corner */}
-                            <div className='border-gold-500 absolute -top-2 -left-2 hidden h-10 w-10 rounded-tl-2xl border-t-2 border-l-2 sm:block' />
-                            <div className='border-gold-500 absolute -right-2 -bottom-2 hidden h-10 w-10 rounded-br-2xl border-r-2 border-b-2 sm:block' />
                         </div>
-
-                        {surgeon.quote && (
-                            <figure className='relative flex flex-col justify-center sm:col-span-3'>
-                                <Quote className='text-gold-500/50 mb-3 h-8 w-8' />
-                                <blockquote className='font-serif text-xl leading-snug text-stone-100 italic md:text-2xl'>
-                                    &ldquo;{surgeon.quote}&rdquo;
-                                </blockquote>
-                                <figcaption className='mt-4 flex items-center gap-3'>
-                                    <span className='from-gold-500 to-gold-300 inline-block h-px w-10 bg-gradient-to-r' />
-                                    <span className='text-gold-400 text-xs font-semibold tracking-[0.2em] uppercase'>
-                                        — Dr. {firstName}
-                                    </span>
-                                </figcaption>
-                            </figure>
-                        )}
                     </div>
 
                     {/* Trust pills */}
-                    <ul className='animate-fade-in-up animate-delay-300 flex flex-wrap gap-2.5'>
+                    <ul className='animate-fade-in-up animate-delay-300 mb-4 flex flex-wrap gap-2.5'>
                         {TRUST_PILLS.map((pill) => (
                             <li
                                 key={pill.label}
@@ -158,38 +137,66 @@ export function DrKarlinskyHero({ id = 'hero' }: DrKarlinskyHeroProps) {
                             </li>
                         ))}
                     </ul>
+
+                    {/* Verification microlinks (replaces full credentials wall) */}
+                    {(healthgradesUrl || realselfUrl) && (
+                        <p className='animate-fade-in-up animate-delay-300 text-xs text-stone-400'>
+                            Verified on{' '}
+                            {healthgradesUrl && (
+                                <a
+                                    href={healthgradesUrl}
+                                    target='_blank'
+                                    rel='noopener noreferrer nofollow'
+                                    className='text-gold-300 hover:text-gold-200 inline-flex items-center gap-0.5 underline underline-offset-2'
+                                >
+                                    Healthgrades
+                                    <ExternalLink className='h-3 w-3' />
+                                </a>
+                            )}
+                            {healthgradesUrl && realselfUrl && (
+                                <span className='text-stone-500'> · </span>
+                            )}
+                            {realselfUrl && (
+                                <a
+                                    href={realselfUrl}
+                                    target='_blank'
+                                    rel='noopener noreferrer nofollow'
+                                    className='text-gold-300 hover:text-gold-200 inline-flex items-center gap-0.5 underline underline-offset-2'
+                                >
+                                    RealSelf
+                                    <ExternalLink className='h-3 w-3' />
+                                </a>
+                            )}
+                        </p>
+                    )}
                 </div>
 
-                {/* RIGHT — Sticky form */}
+                {/* RIGHT — Sticky compact form */}
                 <div className='animate-fade-in-up animate-delay-200 lg:col-span-5'>
                     <div className='lg:sticky lg:top-32'>
                         <div
                             id={HERO_FORM_ID}
-                            className='ring-gold-500/10 relative rounded-2xl bg-white p-6 shadow-2xl ring-1 shadow-stone-950/40 sm:rounded-3xl md:p-8'
+                            className='ring-gold-500/20 relative rounded-2xl border border-white/10 bg-stone-900/80 p-6 shadow-2xl ring-1 shadow-stone-950/60 backdrop-blur-xl sm:rounded-3xl md:p-8'
                         >
                             {/* Gold tag */}
                             <div className='from-gold-500 to-gold-400 absolute -top-3 left-6 inline-flex items-center gap-1.5 rounded-full bg-gradient-to-r px-3 py-1 shadow-lg'>
                                 <span className='text-[10px] font-bold tracking-[0.18em] text-stone-950 uppercase'>
-                                    Free · No Obligation
+                                    Free · 24-hr response
                                 </span>
                             </div>
 
                             <ConsultationForm
-                                title={`Book With Dr. ${firstName}`}
-                                subtitle='Complimentary consult • 24-hour response • 100% confidential'
+                                title='Tell us a little about you'
+                                subtitle="We'll text you within 24 hours."
                                 source={CONTACT_SOURCES.DR_KARLINSKY_LANDING}
                                 analyticsFormName='dr_karlinsky_hero_form'
                                 enableAnalytics
                                 redirectOnSuccess='/thank-you'
-                                showPreferredContactTime
+                                compact
+                                submitText='Book My Consult'
+                                footerNote="We'll never spam, sell, or share your data."
                             />
                         </div>
-
-                        {/* Below-form micro-trust */}
-                        <p className='mt-4 text-center text-xs text-stone-400'>
-                            Your information is private. We&apos;ll never spam,
-                            sell, or share your data.
-                        </p>
                     </div>
                 </div>
             </div>

--- a/apps/web/components/dr-karlinsky-landing/dr-karlinsky-minimal-header.component.tsx
+++ b/apps/web/components/dr-karlinsky-landing/dr-karlinsky-minimal-header.component.tsx
@@ -3,16 +3,12 @@
  *
  * Stripped-down header for the ad landing page. Contains only:
  *   - Alluring logo (NOT a link to home — keeps visitors on the LP)
- *   - Phone number (tap-to-call)
  *   - "Book Consult" CTA scrolling to the hero form
  *
- * No nav. No exits. Sticky to the top so the CTA is always one click away.
+ * No nav. No exits. No phone. Sticky so the CTA is always one tap away.
  */
 import { Button } from '@workspace/ui/components/button'
-import { Phone } from 'lucide-react'
 import Image from 'next/image'
-
-import { getPhoneLink, siteConfig } from '@/lib/data/site-config'
 
 export type DrKarlinskyMinimalHeaderProps = {
     readonly formAnchor?: string
@@ -21,8 +17,6 @@ export type DrKarlinskyMinimalHeaderProps = {
 export function DrKarlinskyMinimalHeader({
     formAnchor = '#hero-form',
 }: DrKarlinskyMinimalHeaderProps) {
-    const phoneHref = getPhoneLink()
-
     return (
         <header className='sticky top-0 z-40 w-full border-b border-stone-200/60 bg-white/85 backdrop-blur-xl'>
             <div className='mx-auto flex h-16 w-full max-w-7xl items-center justify-between gap-4 px-4 sm:h-[72px] md:px-8'>
@@ -38,33 +32,16 @@ export function DrKarlinskyMinimalHeader({
                     />
                 </div>
 
-                {/* Right cluster: phone + book button */}
-                <div className='flex items-center gap-2 sm:gap-4'>
-                    {/* Phone — visible everywhere; collapses to icon on small screens */}
-                    <a
-                        href={phoneHref}
-                        className='hover:bg-gold-50 hover:text-gold-700 inline-flex items-center gap-2 rounded-full px-3 py-2 text-sm font-medium text-stone-700 transition-colors'
-                        aria-label={`Call ${siteConfig.contact.phoneDisplay}`}
-                    >
-                        <Phone className='text-gold-600 h-4 w-4 shrink-0' />
-                        <span className='hidden sm:inline'>
-                            {siteConfig.contact.phoneDisplay}
-                        </span>
+                <Button
+                    asChild
+                    size='sm'
+                    className='bg-gold-500 hover:bg-gold-600 px-4 text-xs font-bold tracking-wide text-white uppercase shadow-md shadow-amber-500/20 transition-shadow hover:shadow-lg hover:shadow-amber-500/30 sm:px-6 sm:text-sm'
+                >
+                    <a href={formAnchor}>
+                        <span className='hidden sm:inline'>Book Consult</span>
+                        <span className='sm:hidden'>Book</span>
                     </a>
-
-                    <Button
-                        asChild
-                        size='sm'
-                        className='bg-gold-500 hover:bg-gold-600 px-4 text-xs font-bold tracking-wide text-white uppercase shadow-md shadow-amber-500/20 transition-shadow hover:shadow-lg hover:shadow-amber-500/30 sm:px-6 sm:text-sm'
-                    >
-                        <a href={formAnchor}>
-                            <span className='hidden sm:inline'>
-                                Book Consult
-                            </span>
-                            <span className='sm:hidden'>Book</span>
-                        </a>
-                    </Button>
-                </div>
+                </Button>
             </div>
         </header>
     )

--- a/apps/web/components/dr-karlinsky-landing/dr-karlinsky-specialties.component.tsx
+++ b/apps/web/components/dr-karlinsky-landing/dr-karlinsky-specialties.component.tsx
@@ -1,9 +1,9 @@
 /**
  * DrKarlinskySpecialties
  *
- * 8-card specialty grid mapped to real procedure pages. Each card invites
- * deeper research (link to procedure detail) AND offers a fast-path back to
- * the hero form for visitors ready to book without reading more.
+ * Six top-of-mind procedures for IG-bio-link traffic. Trimmed from
+ * eight to keep the grid one-screen-tall on mobile and to bias toward
+ * the procedures Dr. K's IG audience actually asks about.
  */
 import { ArrowDownRight } from 'lucide-react'
 import Link from 'next/link'
@@ -18,36 +18,28 @@ type SpecialtyCard = {
 
 const SPECIALTIES: readonly SpecialtyCard[] = [
     {
-        title: 'Brazilian Butt Lift (BBL)',
-        tagline: 'Sculpted curves with safety-first technique.',
+        title: 'Brazilian Butt Lift',
+        tagline: 'Sculpted curves, safety first.',
     },
     {
         title: 'Mommy Makeover',
-        tagline: 'Reclaim your pre-pregnancy silhouette.',
+        tagline: 'Pre-pregnancy silhouette, restored.',
     },
     {
-        title: 'Tummy Tuck (Abdominoplasty)',
+        title: 'Tummy Tuck',
         tagline: 'A flatter, firmer midsection.',
     },
     {
-        title: 'Liposuction & Lipo 360',
-        tagline: 'Full-body contouring with precision.',
+        title: 'Lipo 360',
+        tagline: 'Full-body contouring, precise.',
     },
     {
         title: 'Breast Augmentation & Lift',
-        tagline: 'Natural shape, balanced proportions.',
-    },
-    {
-        title: 'Breast Reduction',
-        tagline: 'Comfort and confidence restored.',
+        tagline: 'Natural shape. Balanced proportions.',
     },
     {
         title: 'Facelift',
-        tagline: 'Refreshed, rested — never overdone.',
-    },
-    {
-        title: 'Blepharoplasty (Eyelid)',
-        tagline: 'Brighter, more open eyes.',
+        tagline: 'Refreshed — never overdone.',
     },
 ] as const
 
@@ -74,22 +66,18 @@ export function DrKarlinskySpecialties({
             >
                 <div className='mx-auto mb-14 max-w-3xl text-center lg:mb-16'>
                     <p className='text-gold-600 mb-3 text-xs font-bold tracking-[0.22em] uppercase'>
-                        Procedures Performed by Dr. Karlinsky
+                        What Dr. Karlinsky Does
                     </p>
                     <h2 className='font-serif text-3xl leading-tight text-stone-900 md:text-4xl lg:text-5xl'>
-                        Eight signature procedures.{' '}
-                        <span className='text-gold-600 italic'>
-                            One uncompromising standard.
-                        </span>
+                        What women fly into Miami{' '}
+                        <span className='text-gold-600 italic'>for.</span>
                     </h2>
                     <p className='mt-4 text-base leading-relaxed text-stone-600 lg:text-lg'>
-                        Each plan is built around <em>your</em> anatomy and
-                        goals. Not sure which procedure fits? Dr. Karlinsky will
-                        walk you through every option in your free consult.
+                        Tap any procedure and we&apos;ll start the conversation.
                     </p>
                 </div>
 
-                <ul className='grid gap-4 sm:grid-cols-2 lg:grid-cols-4 lg:gap-5'>
+                <ul className='grid gap-4 sm:grid-cols-2 lg:grid-cols-3 lg:gap-5'>
                     {SPECIALTIES.map((specialty, index) => (
                         <li key={specialty.title}>
                             <Link
@@ -125,16 +113,16 @@ export function DrKarlinskySpecialties({
                 </ul>
 
                 {/* Bottom redirect to form */}
-                <div className='mt-12 flex flex-col items-center gap-3 text-center'>
+                <div className='mt-12 flex flex-col items-center gap-2 text-center'>
                     <p className='text-stone-600'>
-                        Considering more than one? Dr. Karlinsky often combines
-                        procedures safely in a single session.
+                        Combining two? Dr. Karlinsky does that, safely, all the
+                        time.
                     </p>
                     <Link
                         href={formAnchor}
                         className='text-gold-700 hover:text-gold-800 hover:decoration-gold-500 inline-flex items-center gap-2 font-medium underline decoration-stone-300 underline-offset-4 transition-colors'
                     >
-                        Discuss your combination
+                        Discuss yours
                         <span aria-hidden='true'>↑</span>
                     </Link>
                 </div>

--- a/apps/web/components/dr-karlinsky-landing/dr-karlinsky-sticky-mobile-cta.component.tsx
+++ b/apps/web/components/dr-karlinsky-landing/dr-karlinsky-sticky-mobile-cta.component.tsx
@@ -1,0 +1,89 @@
+/**
+ * DrKarlinskyStickyMobileCTA
+ *
+ * Mobile-only fixed bottom bar that keeps the booking action one thumb-tap
+ * away anywhere on the page. Hides while the hero form is in the viewport
+ * (so it doesn't double up) and reveals once the visitor scrolls past it.
+ *
+ * Companion to the warm-traffic Instagram landing page — the visitor
+ * expects this kind of always-visible action chip from native social
+ * apps, and it consistently lifts mobile conversion by removing the
+ * "scroll back up to book" friction.
+ */
+'use client'
+
+import Link from 'next/link'
+import { useEffect, useState } from 'react'
+
+export type DrKarlinskyStickyMobileCTAProps = {
+    /** Anchor for the primary "Book" action (defaults to #hero-form) */
+    readonly formAnchor?: string
+    /** ID of the hero form to observe — bar hides while this is on screen */
+    readonly heroFormId?: string
+}
+
+export function DrKarlinskyStickyMobileCTA({
+    formAnchor = '#hero-form',
+    heroFormId = 'hero-form',
+}: DrKarlinskyStickyMobileCTAProps) {
+    const [isVisible, setIsVisible] = useState(false)
+
+    useEffect(() => {
+        const heroForm = document.getElementById(heroFormId)
+
+        let scrolledPastThreshold = false
+        let heroFormOnScreen = true
+
+        const updateVisibility = () => {
+            setIsVisible(scrolledPastThreshold && !heroFormOnScreen)
+        }
+
+        const handleScroll = () => {
+            scrolledPastThreshold = window.scrollY > 600
+            updateVisibility()
+        }
+
+        handleScroll()
+        window.addEventListener('scroll', handleScroll, { passive: true })
+
+        let observer: IntersectionObserver | null = null
+        if (heroForm) {
+            observer = new IntersectionObserver(
+                ([entry]) => {
+                    heroFormOnScreen = entry?.isIntersecting ?? false
+                    updateVisibility()
+                },
+                { threshold: 0.15 }
+            )
+            observer.observe(heroForm)
+        } else {
+            heroFormOnScreen = false
+            updateVisibility()
+        }
+
+        return () => {
+            window.removeEventListener('scroll', handleScroll)
+            observer?.disconnect()
+        }
+    }, [heroFormId])
+
+    return (
+        <div
+            aria-hidden={!isVisible}
+            className={`pb-safe fixed inset-x-0 bottom-0 z-40 border-t border-white/10 bg-stone-950/90 backdrop-blur-xl transition-all duration-300 lg:hidden ${
+                isVisible
+                    ? 'translate-y-0 opacity-100'
+                    : 'pointer-events-none translate-y-full opacity-0'
+            }`}
+        >
+            <div className='px-4 py-3'>
+                <Link
+                    href={formAnchor}
+                    className='from-gold-500 to-gold-400 hover:from-gold-400 hover:to-gold-300 flex w-full items-center justify-center rounded-full bg-gradient-to-r px-5 py-3 text-sm font-bold tracking-wide text-stone-950 shadow-lg shadow-stone-950/40 transition-all active:scale-[0.98]'
+                >
+                    Book My Consult
+                </Link>
+            </div>
+        </div>
+    )
+}

--- a/apps/web/components/layout/non-standalone-only.component.tsx
+++ b/apps/web/components/layout/non-standalone-only.component.tsx
@@ -1,0 +1,33 @@
+'use client'
+
+import { usePathname } from 'next/navigation'
+import type { ReactNode } from 'react'
+
+/**
+ * Routes that should NOT receive global floating chrome (mobile call button,
+ * beta feedback widget, etc). Mirrors the STANDALONE_ROUTES list in
+ * ConditionalLayout — landing and link-in-bio pages ship their own chrome.
+ */
+const STANDALONE_ROUTES = ['/links', '/landing']
+
+export interface NonStandaloneOnlyProps {
+    children: ReactNode
+}
+
+/**
+ * Renders children only when the current route is NOT a standalone route.
+ * Use to gate global floating widgets that should be suppressed on
+ * landing pages and other minimal-chrome routes.
+ */
+export function NonStandaloneOnly({ children }: NonStandaloneOnlyProps) {
+    const pathname = usePathname()
+    const isStandalone = STANDALONE_ROUTES.some((route) =>
+        pathname.startsWith(route)
+    )
+
+    if (isStandalone) {
+        return null
+    }
+
+    return <>{children}</>
+}

--- a/apps/web/components/shared/forms/consultation-form.component.tsx
+++ b/apps/web/components/shared/forms/consultation-form.component.tsx
@@ -22,7 +22,7 @@ import { zodResolver } from '@hookform/resolvers/zod'
 import { Form } from '@workspace/ui/components/form'
 import { CheckCircle2 } from 'lucide-react'
 import Link from 'next/link'
-import { useForm } from 'react-hook-form'
+import { type Resolver, useForm } from 'react-hook-form'
 
 import { FormFeedback } from '@/components/shared/forms/form-feedback.component'
 import {
@@ -39,6 +39,7 @@ import { siteConfig } from '@/lib/data/site-config'
 import {
     type ConsultationFormInput,
     type ContactSource,
+    consultationFormCompactSchema,
     consultationFormSchema,
     PREFERRED_CONTACT_TIME_OPTIONS,
     PROCEDURE_OPTIONS,
@@ -68,6 +69,18 @@ export type ConsultationFormProps = {
     readonly showPreferredContactTime?: boolean
     /** Default procedure value for pre-populating the procedure dropdown */
     readonly defaultProcedure?: string
+    /**
+     * Mobile-first compact variant. When true:
+     * - Hides Last Name, Email, and Preferred Contact Time fields
+     * - Only First Name + Phone + Procedure (optional) + Consent are visible
+     * - Uses the relaxed `consultationFormCompactSchema`
+     * - Replaces the default submit copy unless `submitText` is set
+     */
+    readonly compact?: boolean
+    /** Custom submit button label (overrides default) */
+    readonly submitText?: string
+    /** Custom privacy/footer note below the submit button */
+    readonly footerNote?: string
 }
 
 /**
@@ -97,9 +110,14 @@ export function ConsultationForm({
     redirectOnSuccess,
     showPreferredContactTime = true,
     defaultProcedure,
+    compact = false,
+    submitText,
+    footerNote,
 }: ConsultationFormProps) {
     const form = useForm<ConsultationFormInput>({
-        resolver: zodResolver(consultationFormSchema),
+        resolver: zodResolver(
+            compact ? consultationFormCompactSchema : consultationFormSchema
+        ) as Resolver<ConsultationFormInput>,
         defaultValues: {
             firstName: '',
             lastName: '',
@@ -194,8 +212,8 @@ export function ConsultationForm({
                             />
                         </div>
 
-                        {/* First Name & Last Name Row */}
-                        <div className='grid gap-6 md:grid-cols-2'>
+                        {/* Name row — last name hidden in compact mode */}
+                        {compact ? (
                             <FirstNameField
                                 control={form.control}
                                 name='firstName'
@@ -205,28 +223,31 @@ export function ConsultationForm({
                                 variant='dark'
                                 required
                             />
-                            <LastNameField
-                                control={form.control}
-                                name='lastName'
-                                label='Last Name'
-                                placeholder='Last name'
-                                disabled={isSubmitting}
-                                variant='dark'
-                                required
-                            />
-                        </div>
+                        ) : (
+                            <div className='grid gap-6 md:grid-cols-2'>
+                                <FirstNameField
+                                    control={form.control}
+                                    name='firstName'
+                                    label='First Name'
+                                    placeholder='First name'
+                                    disabled={isSubmitting}
+                                    variant='dark'
+                                    required
+                                />
+                                <LastNameField
+                                    control={form.control}
+                                    name='lastName'
+                                    label='Last Name'
+                                    placeholder='Last name'
+                                    disabled={isSubmitting}
+                                    variant='dark'
+                                    required
+                                />
+                            </div>
+                        )}
 
-                        {/* Email & Phone Row */}
-                        <div className='grid gap-6 md:grid-cols-2'>
-                            <EmailField
-                                control={form.control}
-                                name='email'
-                                label='Email'
-                                placeholder='your@email.com'
-                                disabled={isSubmitting}
-                                variant='dark'
-                                required
-                            />
+                        {/* Phone always shown; email hidden in compact mode */}
+                        {compact ? (
                             <PhoneField
                                 control={form.control}
                                 name='phone'
@@ -236,7 +257,28 @@ export function ConsultationForm({
                                 variant='dark'
                                 required
                             />
-                        </div>
+                        ) : (
+                            <div className='grid gap-6 md:grid-cols-2'>
+                                <EmailField
+                                    control={form.control}
+                                    name='email'
+                                    label='Email'
+                                    placeholder='your@email.com'
+                                    disabled={isSubmitting}
+                                    variant='dark'
+                                    required
+                                />
+                                <PhoneField
+                                    control={form.control}
+                                    name='phone'
+                                    label='Phone Number'
+                                    placeholder='(555) 555-5555'
+                                    disabled={isSubmitting}
+                                    variant='dark'
+                                    required
+                                />
+                            </div>
+                        )}
 
                         {/* Procedure Selector */}
                         <SelectField
@@ -248,8 +290,8 @@ export function ConsultationForm({
                             options={PROCEDURE_OPTIONS}
                         />
 
-                        {/* Preferred Contact Time - Optional based on prop */}
-                        {showPreferredContactTime && (
+                        {/* Preferred Contact Time - hidden in compact mode */}
+                        {!compact && showPreferredContactTime && (
                             <SelectField
                                 control={form.control}
                                 name='preferredContactTime'
@@ -308,14 +350,17 @@ export function ConsultationForm({
                                 showSendIcon
                                 showSparkles
                             >
-                                Yes, I Want My Free Consultation
+                                {submitText ??
+                                    (compact
+                                        ? 'Book My Consult'
+                                        : 'Yes, I Want My Free Consultation')}
                             </SubmitButton>
                         </div>
 
                         {/* Privacy Note */}
                         <p className='text-center text-xs text-stone-500'>
-                            Your information is private and secure. We respond
-                            within 24 hours.
+                            {footerNote ??
+                                'Your information is private and secure. We respond within 24 hours.'}
                         </p>
                     </form>
                 </Form>

--- a/apps/web/lib/data/faq/dr-karlinsky-faq.data.ts
+++ b/apps/web/lib/data/faq/dr-karlinsky-faq.data.ts
@@ -1,100 +1,53 @@
 /**
  * Dr. Victoria Karlinsky Landing Page FAQ Data
  *
- * Categorized FAQ items tailored to the doctor-specific landing page.
- * Categories address the four objection clusters most common when
- * choosing a surgeon: who she is, the consult itself, safety/results,
- * and cost/financing.
+ * Tightly scoped FAQ for warm Instagram-bio-link traffic. Six questions,
+ * two categories — only the objections IG-warm visitors actually voice
+ * before booking: price, financing, recovery, safety/results, language,
+ * and virtual consults.
  */
-import { siteConfig } from '@/lib/data/site-config'
 import type { FaqCategory, FaqItem } from '@/lib/types/shared/faq.type'
 
 export const drKarlinskyFaqCategories: FaqCategory[] = [
-    { id: 'about', label: 'About Dr. Karlinsky' },
-    { id: 'consultation', label: 'Your Consultation' },
-    { id: 'safety', label: 'Safety & Results' },
-    { id: 'cost', label: 'Cost & Financing' },
+    { id: 'booking-cost', label: 'Booking & Cost' },
+    { id: 'safety-results', label: 'Safety & Results' },
 ]
 
 export const drKarlinskyFaqData: Record<string, FaqItem[]> = {
-    about: [
+    'booking-cost': [
         {
-            question: 'Is Dr. Karlinsky board certified?',
-            answer: `Yes — and not by one board, but three. Dr. Victoria Karlinsky is certified by the American Board of Cosmetic Surgery, the American Board of Facial Cosmetic Surgery, and the American Board of Surgery. She is also a Fellow of the American College of Surgeons (FACS), a Fellow of the American Academy of Cosmetic Surgery, and a Fellowship Director with the American Board of Cosmetic Surgery.`,
+            question: 'How much does it cost?',
+            answer: `Pricing depends on the procedure. Every quote is all-inclusive — surgeon, anesthesia, facility, follow-up — with no hidden add-ons. You'll get a personalized quote at your free consult.`,
         },
         {
-            question: 'How experienced is she?',
-            answer: `Dr. Karlinsky has performed thousands of cosmetic and reconstructive procedures throughout her career. She trained at Beth Israel Medical Center in NYC and completed a fellowship at the Facial Plastic & Cosmetic Surgical Center in Texas. As a Fellowship Director, she now trains other surgeons in advanced cosmetic surgery techniques.`,
+            question: 'What financing do you offer?',
+            answer: `We partner with Cherry, CareCredit, and United Credit. Many patients qualify for 0% APR for 12–24 months, and weekly payments often start around $27/week.`,
         },
         {
-            question: 'What is her surgical philosophy?',
-            answer: `Three pillars: safety first, personalization always, and natural results. She rejects the "one-size-fits-all" approach — every plan is built around your anatomy, your goals, and your lifestyle. The aim is never "obvious work" — it's a more confident version of you.`,
-        },
-        {
-            question: 'Where can I verify her credentials?',
-            answer: `Every credential listed on this page is independently verifiable. You can find Dr. Karlinsky's verified profiles on Healthgrades and RealSelf — both linked in the credentials section above. Board certifications can also be looked up directly on each board's website.`,
+            question: 'Can I do a virtual consult first?',
+            answer: `Yes. Most out-of-state and international patients start virtual — discuss your goals, see preliminary options, get a quote estimate — then fly in for surgery.`,
         },
     ],
-    consultation: [
-        {
-            question: 'What happens during the consultation?',
-            answer: `You'll meet privately with Dr. Karlinsky to discuss your goals. She'll evaluate your anatomy, walk you through suitable options, show you before-and-after results from similar cases, and provide a detailed all-inclusive quote. There's no pressure to make a decision — many patients book a consult months before deciding.`,
-        },
-        {
-            question: 'Is the consultation really free?',
-            answer: `Yes, completely complimentary with no obligation. We don't charge for an initial consultation because we want you to feel fully informed before committing to anything.`,
-        },
-        {
-            question: 'Can I do a virtual consultation first?',
-            answer: `Absolutely. Many out-of-state and international patients start with a virtual consult. You can discuss your goals, see preliminary recommendations, and get a quote estimate before flying to Miami.`,
-        },
-        {
-            question: 'How soon can I book?',
-            answer: `Consultation appointments are typically available within 1–2 weeks. Call us at ${siteConfig.contact.phoneDisplay} or fill out the form above and our patient concierge will work around your schedule.`,
-        },
-    ],
-    safety: [
-        {
-            question: 'Is plastic surgery actually safe?',
-            answer: `When performed by a triple board-certified surgeon in an accredited facility, the risk profile is excellent. Dr. Karlinsky's safety standards meet — and often exceed — what's required by the boards she sits on. Hospital-grade protocols, advanced monitoring, and a dedicated anesthesiology team accompany every procedure.`,
-        },
+    'safety-results': [
         {
             question: 'Will I look natural — or "done"?',
-            answer: `Natural is the entire point. Dr. Karlinsky tailors each procedure to your existing proportions and features. The goal is always "you, refreshed" — never the obvious cookie-cutter look. Bring inspiration photos to your consultation; she'll be candid about what's achievable for your anatomy.`,
-        },
-        {
-            question: 'Can she combine multiple procedures safely?',
-            answer: `Often, yes. Many patients save recovery time by combining a Mommy Makeover (tummy tuck + breast surgery + lipo) into one session. Whether combination is safe for you depends on your health, the specific procedures, and total surgical time. Dr. Karlinsky will give you a candid recommendation in your consult.`,
+            answer: `Natural is the entire point. Dr. Karlinsky tailors every plan to your proportions. The goal is always "you, refreshed" — never the cookie-cutter look.`,
         },
         {
             question: 'How long is recovery?',
-            answer: `Recovery varies by procedure. Most patients return to desk work in 1–2 weeks and resume full activities in 4–6 weeks. Dr. Karlinsky will give you a procedure-specific recovery timeline at your consultation, plus a 24/7 concierge contact for the entire post-op period.`,
-        },
-    ],
-    cost: [
-        {
-            question: 'How much does Dr. Karlinsky cost?',
-            answer: `Pricing depends on the procedure(s), surgical complexity, and recovery support you need. Quotes are all-inclusive — surgeon's fees, anesthesia, facility, and standard follow-up — with no hidden add-ons. You'll receive your personalized quote at the end of your consult.`,
+            answer: `Most patients are back at desk work in 1–2 weeks and at full activity in 4–6 weeks. You'll get a procedure-specific timeline at your consult, plus 24/7 post-op concierge contact.`,
         },
         {
-            question: 'What financing do you accept?',
-            answer: `We partner with Cherry, CareCredit, and United Credit. Many patients qualify for 0% APR for 12–24 months, and weekly payments often start as low as $27/week depending on the procedure and approved term. You can apply for pre-approval before your consult so you know your budget walking in.`,
-        },
-        {
-            question: 'Are there any hidden fees?',
-            answer: `Never. The quote you receive includes the surgeon's fee, anesthesia, facility costs, and your standard post-op follow-up. We believe in complete transparency — what we quote is what you pay.`,
-        },
-        {
-            question: 'Is the deposit refundable?',
-            answer: `If your surgery is cancelled by us for medical reasons, your deposit is fully refunded. Patient-initiated cancellations and reschedules are handled case-by-case — we'll walk you through the policy clearly before you put anything down.`,
+            question: '¿Hablan español?',
+            answer: `Sí. Toda la consulta y el cuidado postoperatorio están disponibles en español. Just let us know when you book.`,
         },
     ],
 }
 
 export const drKarlinskyFaqConfig = {
     badge: 'Honest Answers',
-    title: 'Questions Patients Ask About',
-    subtitle: 'Dr. Karlinsky.',
+    title: 'The questions we hear',
+    subtitle: 'before every consult.',
     description:
-        "If you're researching surgeons (and you should be), here are the questions we hear most. Don't see yours? Bring it to your consult.",
+        "Six things almost every patient wants to know upfront. Don't see yours? Bring it to your consult — no question is off-limits.",
 }

--- a/apps/web/lib/types/forms/contact-form.type.ts
+++ b/apps/web/lib/types/forms/contact-form.type.ts
@@ -465,6 +465,24 @@ export type ConsultationFormInput = z.input<typeof consultationFormSchema>
 export type ConsultationFormData = z.output<typeof consultationFormSchema>
 
 /**
+ * Compact consultation form schema
+ * Mobile-first variant for warm-traffic landing pages where every
+ * field cut compounds into a higher submit rate. Only firstName,
+ * phone, and consent are required. lastName/email are dropped from
+ * the UI entirely (callback will capture what we need).
+ */
+export const consultationFormCompactSchema = z.object({
+    firstName: firstNameSchema,
+    lastName: lastNameSchema.optional(),
+    email: emailSchema,
+    phone: requiredPhoneSchema,
+    procedure: z.string().optional(),
+    preferredContactTime: preferredContactTimeSchema,
+    consentGiven: consentSchema,
+    _website: z.string().optional(),
+})
+
+/**
  * Lead capture schema - minimal fields for conversion-focused forms
  * Used by: BlogCTA footer, ExitIntentPopup, LeadForm
  * Name is optional to minimize friction in lead capture forms


### PR DESCRIPTION
## Summary

- Rewrites `/landing/dr-victoria-karlinsky` for warm IG-bio-link traffic: cuts 14 sections → 8, ~5,000 words → ~750, drops two competing forms in favor of one compact 3-field hero form, and reorders the page to lead with results (gallery → reviews) before procedures and FAQs.
- New IG-aware copy throughout: hero (*"You followed her work. Now let's plan yours."*), specialties (*"What women fly into Miami for."*), final CTA (*"Let's plan yours."*); FAQ trimmed from 16 questions across 4 categories to **6** questions in **2** categories scoped to what IG-warm visitors actually ask (cost, financing, virtual, naturalness, recovery, español).
- Strips all phone/call CTAs from the LP per follow-up: header, FAQ bottom CTA, final-CTA secondary button, sticky mobile CTA's call icon, and the global floating `MobileCallButton` (now suppressed on `/landing` and `/links` via a new `NonStandaloneOnly` wrapper that mirrors `ConditionalLayout`'s standalone-route logic).
- Adds `compact` / `submitText` / `footerNote` props plus `consultationFormCompactSchema` to the shared `ConsultationForm`. Compact mode hides Last Name, Email, and Preferred Contact Time, leaving First Name + Phone + optional Procedure + consent.
- New `DrKarlinskyStickyMobileCTA` — mobile-only fixed bottom bar that fades in past 600px scroll and hides while the hero form is on screen.

Components removed from the page (files retained for reuse on other LPs): `DrKarlinskyAbout`, `DrKarlinskyWhyChoose`, `DrKarlinskyTrustStrip`, `DrKarlinskyCredentialsWall`, `MiniLeadCapture`.

## Test plan

- [ ] `pnpm dev`, visit `/dr-karlinsky-ig` → confirm 308 redirect to `/landing/dr-victoria-karlinsky?utm_source=doctor&utm_medium=dr-karlinsky` still fires
- [ ] Mobile viewport (414×896): hero form renders 3 fields above the fold (First Name, Phone, Procedure)
- [ ] Sticky bottom bar fades in after ~600px scroll and disappears when scrolling back to the hero form
- [ ] No phone link / call CTA visible anywhere on the LP (header, FAQ bottom, final CTA, floating widget)
- [ ] Submit hero form with valid data → POST `/api/contact` succeeds with `source: dr-karlinsky-landing` → redirect to `/thank-you`
- [ ] Specialties grid shows 6 cards, every card scrolls to `#hero-form`
- [ ] FAQ shows 2 categories totaling 6 questions
- [ ] Visit a non-standalone page (homepage) and confirm the global `MobileCallButton` still renders if the env flag is on
- [ ] `pnpm build` succeeds; no console hydration regressions on the LP

🤖 Generated with [Claude Code](https://claude.com/claude-code)