### PR TITLE
feat(chat): add Loquent chat widget with env toggle

### DIFF
--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -81,6 +81,9 @@ export default function RootLayout({
     // Check if chat widget is enabled (default: true, fetches config from API)
     const isChatEnabled = env.NEXT_PUBLIC_CHAT_ENABLED !== 'false'
 
+    // Check if Loquent external chat widget is enabled (default: false)
+    const isLoquentChatEnabled = env.NEXT_PUBLIC_LOQUENT_CHAT_ENABLED === 'true'
+
     // Check if cookie banner should be enabled (default: true)
     const isCookieBannerEnabled =
         env.NEXT_PUBLIC_ENABLE_COOKIE_BANNER !== 'false'
@@ -117,6 +120,16 @@ export default function RootLayout({
                         `,
                     }}
                 />
+
+                {/* Loquent Chat Widget */}
+                {isLoquentChatEnabled && (
+                    <Script
+                        id='loquent-widget'
+                        src='https://app.loquent.io/api/widget/embed.js'
+                        strategy='afterInteractive'
+                        data-widget='wid_554cd1300f244407ab084a095f3e1c1d'
+                    />
+                )}
             </head>
             <body
                 className={`${fontLato.variable} ${fontMono.variable} ${fontGeist.variable} ${fontPlayfair.variable} font-sans antialiased`}

--- a/apps/web/env.ts
+++ b/apps/web/env.ts
@@ -96,6 +96,9 @@ export const env = createEnv({
         // Chat widget enable/disable
         NEXT_PUBLIC_CHAT_ENABLED: z.enum(['true', 'false']).optional(),
 
+        // Loquent external chat widget enable/disable
+        NEXT_PUBLIC_LOQUENT_CHAT_ENABLED: z.enum(['true', 'false']).optional(),
+
         // Cookie banner enable/disable (optional, defaults to enabled)
         NEXT_PUBLIC_ENABLE_COOKIE_BANNER: z.enum(['true', 'false']).optional(),
     },
@@ -126,6 +129,8 @@ export const env = createEnv({
         NEXT_PUBLIC_ALLOW_CRAWLING: process.env.NEXT_PUBLIC_ALLOW_CRAWLING,
         NEXT_PUBLIC_BETA_MODE: process.env.NEXT_PUBLIC_BETA_MODE,
         NEXT_PUBLIC_CHAT_ENABLED: process.env.NEXT_PUBLIC_CHAT_ENABLED,
+        NEXT_PUBLIC_LOQUENT_CHAT_ENABLED:
+            process.env.NEXT_PUBLIC_LOQUENT_CHAT_ENABLED,
         NEXT_PUBLIC_ENABLE_COOKIE_BANNER:
             process.env.NEXT_PUBLIC_ENABLE_COOKIE_BANNER,
         NODE_ENV: process.env.NODE_ENV,


### PR DESCRIPTION
## Summary
- Adds the Loquent external chat widget script to the root layout, loaded via `next/script` with `afterInteractive` strategy.
- Gates the widget behind a new `NEXT_PUBLIC_LOQUENT_CHAT_ENABLED` env flag (defaults to **disabled**) so we can turn it on per environment without running it alongside the internal chat widget.
- Widget ID (`wid_554cd1300f244407ab084a095f3e1c1d`) is currently hardcoded, matching the Harmonee pattern. If we need per-env widget IDs later, we can promote it to env too.

## Notes
- The Loquent config endpoint (`https://app.loquent.io/api/widget/{id}/config`) currently does not return CORS headers, so the widget will fail to initialize until that is fixed on the Loquent server. This PR just gives us a clean toggle in the meantime.

## Test plan
- [ ] With no env set, reload the site — no `<script id="loquent-widget">` in the DOM, no requests to `app.loquent.io`.
- [ ] Set `NEXT_PUBLIC_LOQUENT_CHAT_ENABLED=true` in `apps/web/.env.local`, restart dev server, reload — script tag is present and request fires.
- [ ] `pnpm build` passes with the new env var registered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional Loquent chat widget integration that can be toggled via environment configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Monsoft-Solutions/alluring-website-v1/pull/111?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->