### PR TITLE
feat(redirects): add /kuki influencer bio link

### DIFF
--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -82,6 +82,12 @@ const nextConfig = {
                 permanent: true,
             },
             {
+                source: '/kuki',
+                destination:
+                    '/miami-plastic-surgery-specials?utm_source=influencer&utm_medium=kuki',
+                permanent: true,
+            },
+            {
                 source: '/dr-karlinsky-ig',
                 destination:
                     '/landing/dr-victoria-karlinsky?utm_source=doctor&utm_medium=dr-karlinsky',


### PR DESCRIPTION
## Summary
- Add `/kuki` permanent redirect to the Miami specials page with influencer UTM tags (`utm_source=influencer&utm_medium=kuki`), matching the existing pattern used for other influencer bio links.

## Test plan
- [ ] Visit `/kuki` in production — confirm 308 redirect to `/miami-plastic-surgery-specials?utm_source=influencer&utm_medium=kuki`
- [ ] Confirm UTM parameters land in attribution / analytics

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured URL redirect routing with tracking parameters.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Monsoft-Solutions/alluring-website-v1/pull/112?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->