### PR TITLE
Remove Harmonee tracking and add Dirian Garcia influencer link

### DIFF
--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -103,24 +103,6 @@ export default function RootLayout({
                 <link rel='icon' type='image/png' href='/favicon.png' />
                 <link rel='apple-touch-icon' href='/apple-touch-icon.png' />
 
-                {/* Harmonee Tracking Script */}
-                <Script
-                    id='harmonee-tracking'
-                    strategy='afterInteractive'
-                    dangerouslySetInnerHTML={{
-                        __html: `
-                            (function(s, p, i, c, e) {
-                                s[e] = s[e] || function() { (s[e].a = s[e].a || []).push(arguments); };
-                                s[e].l = 1 * new Date();
-                                var t = new Date().getTime();
-                                var k = c.createElement("script"), a = c.getElementsByTagName("script")[0];
-                                k.async = 1, k.src = p + "?request_id=" + i + "&t=" + t, a.parentNode.insertBefore(k, a);
-                                s.pixelClientId = i;
-                            })(window, "https://app.harmonee.co/script", "alluring", document, "script");
-                        `,
-                    }}
-                />
-
                 {/* Loquent Chat Widget */}
                 {isLoquentChatEnabled && (
                     <Script

--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -88,6 +88,12 @@ const nextConfig = {
                 permanent: true,
             },
             {
+                source: '/dirian-garcia',
+                destination:
+                    '/miami-plastic-surgery-specials?utm_source=influencer&utm_medium=dirian-garcia',
+                permanent: true,
+            },
+            {
                 source: '/dr-karlinsky-ig',
                 destination:
                     '/landing/dr-victoria-karlinsky?utm_source=doctor&utm_medium=dr-karlinsky',


### PR DESCRIPTION
## Summary
- Remove the Harmonee tracking pixel from the site layout
- Add a `/dirian-garcia` redirect to the Miami plastic surgery specials page with influencer UTM attribution (`utm_source=influencer&utm_medium=dirian-garcia`)

## Test plan
- [ ] Confirm the Harmonee script no longer loads in the page source
- [ ] Visit `/dirian-garcia` and verify it redirects to `/miami-plastic-surgery-specials?utm_source=influencer&utm_medium=dirian-garcia`
- [ ] Confirm Loquent chat widget and other analytics scripts still load as expected


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a permanent redirect from `/dirian-garcia` to a new destination with campaign tracking parameters.

* **Bug Fixes**
  * Removed an extra tracking script from the page head while keeping the chat widget available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->