### PR TITLE
feat(chat): switch to Loquent tag webchat, disable built-in chat

### DIFF
--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -78,11 +78,13 @@ export default function RootLayout({
     // Check if beta mode is enabled (shows feedback button)
     const isBetaMode = env.NEXT_PUBLIC_BETA_MODE === 'true'
 
-    // Check if chat widget is enabled (default: true, fetches config from API)
-    const isChatEnabled = env.NEXT_PUBLIC_CHAT_ENABLED !== 'false'
+    // Check if the built-in chat widget is enabled (default: false).
+    // Disabled in favor of the Loquent chat widget below — opt in explicitly.
+    const isChatEnabled = env.NEXT_PUBLIC_CHAT_ENABLED === 'true'
 
-    // Check if Loquent external chat widget is enabled (default: false)
-    const isLoquentChatEnabled = env.NEXT_PUBLIC_LOQUENT_CHAT_ENABLED === 'true'
+    // Check if Loquent external chat widget is enabled (default: true)
+    const isLoquentChatEnabled =
+        env.NEXT_PUBLIC_LOQUENT_CHAT_ENABLED !== 'false'
 
     // Check if cookie banner should be enabled (default: true)
     const isCookieBannerEnabled =
@@ -106,10 +108,10 @@ export default function RootLayout({
                 {/* Loquent Chat Widget */}
                 {isLoquentChatEnabled && (
                     <Script
-                        id='loquent-widget'
-                        src='https://app.loquent.io/api/widget/embed.js'
+                        id='loquent-tag'
+                        src='https://app.loquent.io/api/tag/loquent-tag.js'
                         strategy='afterInteractive'
-                        data-widget='wid_554cd1300f244407ab084a095f3e1c1d'
+                        data-tag='tag_2a2044fdafc54be6b4fdddf3a66442c0'
                     />
                 )}
             </head>

--- a/apps/web/env.example
+++ b/apps/web/env.example
@@ -60,6 +60,9 @@ REVALIDATION_SECRET=your-32-char-minimum-secret-here
 # NEXT_PUBLIC_ENABLE_MOBILE_CALL_BUTTON=true
 # NEXT_PUBLIC_ALLOW_CRAWLING=true
 # NEXT_PUBLIC_BETA_MODE=false
-# NEXT_PUBLIC_CHAT_ENABLED=true
+# Built-in chat widget (default: false — Loquent is used instead). Set to true to re-enable.
+# NEXT_PUBLIC_CHAT_ENABLED=false
+# Loquent external chat widget (default: true). Set to false to disable.
+# NEXT_PUBLIC_LOQUENT_CHAT_ENABLED=true
 # NEXT_PUBLIC_ENABLE_COOKIE_BANNER=true
 


### PR DESCRIPTION
## Summary

Switches the site to the new **Loquent tag webchat** and hides the built-in floating chat so only Loquent's chat is shown.

- Replaced the legacy Loquent widget embed (`api/widget/embed.js` + `data-widget`) with the new tag script (`api/tag/loquent-tag.js` + `data-tag="tag_2a2044fdafc54be6b4fdddf3a66442c0"`), which ships the full webchat + tracking.
- **Loquent chat** is now enabled by default (`NEXT_PUBLIC_LOQUENT_CHAT_ENABLED` must be `false` to disable).
- **Built-in floating chat** (`FloatingChatButton`) is now disabled by default (`NEXT_PUBLIC_CHAT_ENABLED` must be explicitly `true` to re-enable), so it no longer competes with Loquent.
- Updated `env.example` to document the new defaults.

Both toggles remain env-overridable, so either chat can be flipped back without a code change.

## Testing

- `tsc --noEmit` passes on `apps/web`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016XFB8Ukx9ag5Wv4FoHouZh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated chat widget behavior so the built-in chat only appears when explicitly enabled.
  * Added support for a separate Loquent chat option with clearer environment-based control.

* **Bug Fixes**
  * Corrected chat loading behavior so the external chat widget now follows the expected enable/disable setting.
  * Adjusted the chat script integration to load the appropriate chat experience more reliably.

* **Documentation**
  * Updated environment variable examples to reflect the new default chat settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->