### PR TITLE
feat(evaluation): add patient intake & evaluation page with Loquent atrium

### DIFF
--- a/apps/web/app/evaluation/page.tsx
+++ b/apps/web/app/evaluation/page.tsx
@@ -1,0 +1,201 @@
+/**
+ * Patient Evaluation Page
+ *
+ * Hosts the Loquent "Atrium" patient intake & evaluation experience, letting
+ * prospective patients complete a private, guided evaluation so our surgeons
+ * can prepare a personalized plan ahead of the consultation.
+ *
+ * URL: /evaluation
+ *
+ * SEO-optimized for:
+ * - "plastic surgery evaluation miami"
+ * - "virtual surgical consultation intake"
+ */
+import { WebPageSchema } from '@workspace/seo/react'
+import { Award, Clock, Lock, ShieldCheck } from 'lucide-react'
+
+import { ContainerLayout } from '@/components/container-layout.component'
+import { AtriumEmbed } from '@/components/evaluation/atrium-embed.component'
+import { CTASection } from '@/components/shared/cta-section.component'
+import { ContentWrapper } from '@/components/shared/content-wrapper.component'
+import { SectionContainer } from '@/components/shared/section-container.component'
+import { SectionHeader } from '@/components/shared/section-header.component'
+import { siteConfig } from '@/lib/data/site-config'
+import { seoConfig } from '@/lib/seo-config'
+import { toNextMetadata } from '@/lib/seo/metadata'
+
+const pageUrl = `${seoConfig.siteUrl}/evaluation`
+const pageTitle = 'Patient Evaluation | Miami Plastic Surgery | Alluring'
+const pageDescription =
+    'Complete your private, no-obligation plastic surgery evaluation online. Share your goals so our board-certified Miami surgeons can prepare a personalized plan before your consultation.'
+
+export const metadata = toNextMetadata(seoConfig, {
+    canonical: '/evaluation',
+    title: pageTitle,
+    description: pageDescription,
+
+    openGraph: {
+        type: 'website',
+        url: pageUrl,
+        title: pageTitle,
+        description: pageDescription,
+        siteName: seoConfig.siteName,
+        images: [
+            {
+                url: `${seoConfig.siteUrl}/og-image.jpg`,
+                width: 1200,
+                height: 630,
+                alt: `Patient Evaluation - ${siteConfig.business.name} Miami`,
+            },
+        ],
+    },
+
+    twitter: {
+        card: 'summary_large_image',
+        title: pageTitle,
+        description: pageDescription,
+        images: [`${seoConfig.siteUrl}/og-image.jpg`],
+    },
+})
+
+/** Trust signals shown beneath the hero headline. */
+const trustSignals = [
+    { icon: ShieldCheck, label: 'Board-certified surgeons' },
+    { icon: Lock, label: 'Private & secure' },
+    { icon: Clock, label: 'Takes about 5 minutes' },
+    { icon: Award, label: 'No cost, no obligation' },
+] as const
+
+/** Steps shown after the evaluation to set expectations. */
+const nextSteps = [
+    {
+        step: '01',
+        title: 'Complete your evaluation',
+        description:
+            'Answer a few guided questions about your goals, health, and the results you have in mind — at your own pace, in English or Spanish.',
+    },
+    {
+        step: '02',
+        title: 'Our surgeons review it',
+        description:
+            'A board-certified surgeon reviews your responses so your consultation starts with a clear, personalized understanding of your case.',
+    },
+    {
+        step: '03',
+        title: 'Your personalized consultation',
+        description:
+            'We reach out to schedule a consultation and walk you through recommendations, timing, and flexible financing options.',
+    },
+] as const
+
+export default function EvaluationPage() {
+    return (
+        <>
+            <WebPageSchema
+                name={`Patient Evaluation - ${siteConfig.business.name} Miami`}
+                url={pageUrl}
+                description={pageDescription}
+            />
+
+            <ContainerLayout as='main' noPaddingTop noPadding size='full'>
+                {/* Hero */}
+                <SectionContainer
+                    variant='subtle'
+                    paddingY='pt-32 pb-12 lg:pt-40 lg:pb-16'
+                    ariaLabel='Patient evaluation introduction'
+                >
+                    <ContentWrapper size='md' className='text-center'>
+                        <span className='border-gold-300/60 bg-gold-50/60 text-gold-700 inline-flex items-center rounded-full border px-4 py-1.5 text-sm font-medium tracking-wide'>
+                            Virtual Evaluation
+                        </span>
+                        <h1 className='mt-6 font-serif text-4xl font-semibold text-stone-900 sm:text-5xl lg:text-6xl'>
+                            Your Personal Surgical Evaluation
+                        </h1>
+                        <p className='mx-auto mt-6 max-w-2xl text-lg leading-relaxed text-stone-600'>
+                            Take a few private minutes to share your goals. Your
+                            responses help our board-certified surgeons prepare
+                            a personalized plan — so your consultation is
+                            focused entirely on you.
+                        </p>
+
+                        {/* Trust signals */}
+                        <ul className='mx-auto mt-10 flex max-w-3xl flex-wrap items-center justify-center gap-x-6 gap-y-3'>
+                            {trustSignals.map(({ icon: Icon, label }) => (
+                                <li
+                                    key={label}
+                                    className='flex items-center gap-2 text-sm font-medium text-stone-700'
+                                >
+                                    <Icon className='text-gold-600 h-4 w-4' />
+                                    {label}
+                                </li>
+                            ))}
+                        </ul>
+                    </ContentWrapper>
+                </SectionContainer>
+
+                {/* Atrium evaluation embed */}
+                <SectionContainer
+                    variant='default'
+                    paddingY='pb-16 lg:pb-24'
+                    ariaLabel='Begin your evaluation'
+                >
+                    <ContentWrapper size='lg'>
+                        <AtriumEmbed
+                            id='evaluation'
+                            title='Alluring Patient Intake & Evaluation'
+                        />
+                    </ContentWrapper>
+                </SectionContainer>
+
+                {/* What happens next */}
+                <SectionContainer variant='muted' ariaLabel='What happens next'>
+                    <ContentWrapper size='lg'>
+                        <SectionHeader
+                            badge='What Happens Next'
+                            title='A simple path to your consultation'
+                            description='No pressure and no surprises — just a clear, personal process from your first answer to your surgical plan.'
+                            align='center'
+                        />
+
+                        <ol className='mt-14 grid gap-8 md:grid-cols-3'>
+                            {nextSteps.map(({ step, title, description }) => (
+                                <li
+                                    key={step}
+                                    className='rounded-2xl border border-stone-200/70 bg-white/70 p-8 shadow-sm backdrop-blur-sm'
+                                >
+                                    <span className='text-gold-500/80 font-serif text-4xl font-semibold'>
+                                        {step}
+                                    </span>
+                                    <h3 className='mt-4 font-serif text-xl font-semibold text-stone-900'>
+                                        {title}
+                                    </h3>
+                                    <p className='mt-3 leading-relaxed text-stone-600'>
+                                        {description}
+                                    </p>
+                                </li>
+                            ))}
+                        </ol>
+                    </ContentWrapper>
+                </SectionContainer>
+
+                {/* Final CTA */}
+                <CTASection
+                    id='evaluation-cta'
+                    variant='luxury'
+                    eyebrow='Prefer to talk first?'
+                    heading='We are here whenever you are ready'
+                    description='Have a question before you begin? Our patient concierge is happy to help — no pressure, just honest answers.'
+                    primaryButton={{
+                        text: 'Start My Evaluation',
+                        href: '#evaluation',
+                    }}
+                    secondaryButton={{
+                        text: 'Call Us',
+                        href: `tel:${siteConfig.contact.phone.replace(/\D/g, '')}`,
+                    }}
+                    size='lg'
+                />
+            </ContainerLayout>
+        </>
+    )
+}

--- a/apps/web/components/evaluation/atrium-embed.component.tsx
+++ b/apps/web/components/evaluation/atrium-embed.component.tsx
@@ -1,0 +1,53 @@
+/**
+ * Atrium Embed Component
+ *
+ * Embeds the Loquent "Atrium" patient intake & evaluation experience via a
+ * responsive iframe. Server-rendered — the iframe itself is static markup, so
+ * no client boundary is required.
+ *
+ * The iframe is framed in a glassmorphism card consistent with the site's
+ * luxury visual identity.
+ *
+ * @module components/evaluation/atrium-embed
+ */
+
+/** Loquent Atrium identifier for the Alluring Patient Intake & Evaluation flow. */
+const ATRIUM_SRC =
+    'https://app.loquent.io/atrium/atr_162a30df9c69407f9b3ce24a81249d69'
+
+type AtriumEmbedProps = {
+    /** Optional id for anchor links / skip targets. */
+    readonly id?: string
+    /** Accessible title for the embedded evaluation. */
+    readonly title?: string
+}
+
+/**
+ * Renders the Loquent Atrium evaluation inside a premium framed container.
+ */
+export function AtriumEmbed({
+    id,
+    title = 'Alluring Patient Intake & Evaluation',
+}: AtriumEmbedProps) {
+    return (
+        <div id={id} className='relative mx-auto w-full max-w-4xl scroll-mt-32'>
+            {/* Soft gold glow behind the card for depth */}
+            <div
+                aria-hidden='true'
+                className='from-gold-200/40 pointer-events-none absolute -inset-4 -z-10 rounded-[2rem] bg-gradient-to-br to-transparent blur-2xl'
+            />
+
+            {/* Glassmorphism frame */}
+            <div className='rounded-3xl border border-stone-200/60 bg-white/80 p-2 shadow-2xl shadow-stone-900/10 backdrop-blur-xl sm:p-3'>
+                <iframe
+                    src={ATRIUM_SRC}
+                    title={title}
+                    loading='lazy'
+                    allow='clipboard-write'
+                    referrerPolicy='strict-origin-when-cross-origin'
+                    className='h-[640px] w-full rounded-2xl border-0 bg-white'
+                />
+            </div>
+        </div>
+    )
+}


### PR DESCRIPTION
## Summary

Adds a new **`/evaluation`** page that embeds the Loquent **Atrium** patient intake & evaluation experience (`atr_162a30df9c69407f9b3ce24a81249d69`), so prospective patients can complete a private, guided evaluation before their consultation.

### What's included
- **`app/evaluation/page.tsx`** — server-rendered page with SEO metadata, `WebPageSchema`, a hero with trust signals, the atrium embed, a "what happens next" step section, and a closing `CTASection`.
- **`components/evaluation/atrium-embed.component.tsx`** — the Loquent Atrium iframe framed in a glassmorphism card (stone/gold + serif, consistent with the site's design language). Keeps the provided `loading="lazy"` / `allow="clipboard-write"` attributes and adds a `strict-origin-when-cross-origin` referrer policy.

Design follows CLAUDE.md: SSR-first, shared layout components (`SectionContainer`, `ContentWrapper`, `SectionHeader`, `CTASection`), semantic HTML, and no `'use client'`.

## Testing
- `tsc --noEmit` passes on `apps/web`.
- Dev server returns **HTTP 200** for `/evaluation`; hero, atrium iframe, trust signals, and step section are all present in the server-rendered HTML.

> Note: a visual screenshot couldn't be captured because the browser tool's sandbox can't reach the local dev server — verification was done via server-rendered HTML instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016XFB8Ukx9ag5Wv4FoHouZh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new Patient Evaluation page with SEO metadata, social sharing details, and a dedicated `/evaluation` route.
  * Introduced an embedded intake/evaluation section with a responsive form area.
  * Added a clear “What happens next” flow and a final call-to-action area with start and phone contact options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->